### PR TITLE
P4: Live observability — AgentTimeline, expandable tool calls, bug tickets, event history

### DIFF
--- a/backend/src/smrt_agent/agents/coder/loop.py
+++ b/backend/src/smrt_agent/agents/coder/loop.py
@@ -1,6 +1,7 @@
 """Anthropic SDK streaming loop for the Coder agent."""
 import asyncio
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,10 @@ import anthropic
 from smrt_agent.agents.coder.budget import TOOL_DEFINITIONS, compute_cost_usd
 from smrt_agent.agents.coder.tools import read_source_file, write_source_file
 from smrt_agent.agents.reviewer.tools import list_files
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _load_system_prompt() -> str:
@@ -65,7 +70,12 @@ async def run_coder_agent(
                 if hasattr(event, "type") and event.type == "content_block_delta":
                     delta = getattr(event, "delta", None)
                     if delta and getattr(delta, "type", None) == "text_delta":
-                        await queue.put({"type": "coder_text_delta", "text": delta.text})
+                        await queue.put({
+                            "type": "coder_text_delta",
+                            "text": delta.text,
+                            "agent": "coder",
+                            "ts": _ts(),
+                        })
             response = stream.get_final_message()
 
         total_input += response.usage.input_tokens
@@ -78,6 +88,7 @@ async def run_coder_agent(
                 "cost_usd": round(cost, 4),
                 "total_input_tokens": total_input,
                 "total_output_tokens": total_output,
+                "ts": _ts(),
             })
             return
 
@@ -87,6 +98,7 @@ async def run_coder_agent(
                 "total_input_tokens": total_input,
                 "total_output_tokens": total_output,
                 "cost_usd": round(cost, 4),
+                "ts": _ts(),
             })
             return
 
@@ -99,13 +111,15 @@ async def run_coder_agent(
                         "agent": "coder",
                         "tool": block.name,
                         "input": block.input,
+                        "ts": _ts(),
                     })
                     result = _dispatch_tool(block.name, block.input, project_path)
                     await queue.put({
                         "type": "tool_result",
                         "agent": "coder",
                         "tool": block.name,
-                        "result": result[:500],
+                        "result": result[:2000],
+                        "ts": _ts(),
                     })
                     tool_results.append({
                         "type": "tool_result",
@@ -119,5 +133,6 @@ async def run_coder_agent(
         await queue.put({
             "type": "error",
             "message": f"Coder unexpected stop_reason: {response.stop_reason}",
+            "ts": _ts(),
         })
         return

--- a/backend/src/smrt_agent/agents/orchestrator.py
+++ b/backend/src/smrt_agent/agents/orchestrator.py
@@ -1,10 +1,15 @@
 """QA session orchestrator: coordinates QA → HITL → Coder → recheck loop."""
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 
 from smrt_agent.agents.qa.loop import run_qa_agent
 from smrt_agent.agents.coder.loop import run_coder_agent
 from smrt_agent.agents.qa.tools import run_pytest
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 async def run_qa_session(
@@ -25,7 +30,12 @@ async def run_qa_session(
     prior_fix_context: str | None = None
 
     for attempt in range(max_fix_attempts + 1):
-        await queue.put({"type": "session_status", "status": "qa_running", "fix_attempt": attempt})
+        await queue.put({
+            "type": "session_status",
+            "status": "qa_running",
+            "fix_attempt": attempt,
+            "ts": _ts(),
+        })
 
         ticket_id = await run_qa_agent(
             project_path=project_path,
@@ -37,7 +47,12 @@ async def run_qa_session(
         )
 
         if ticket_id is None:
-            await queue.put({"type": "session_status", "status": "done", "fix_attempt": attempt})
+            await queue.put({
+                "type": "session_status",
+                "status": "done",
+                "fix_attempt": attempt,
+                "ts": _ts(),
+            })
             return "done"
 
         if attempt >= max_fix_attempts:
@@ -45,17 +60,22 @@ async def run_qa_session(
                 "type": "session_status",
                 "status": "error",
                 "message": "Max fix attempts reached",
+                "ts": _ts(),
             })
             return "error"
 
-        # HITL gate — pause until user approves or skips
         await queue.put({
             "type": "hitl_request",
             "session_id": session_id,
             "ticket_id": ticket_id,
             "fix_attempt": attempt,
+            "ts": _ts(),
         })
-        await queue.put({"type": "session_status", "status": "hitl_waiting"})
+        await queue.put({
+            "type": "session_status",
+            "status": "hitl_waiting",
+            "ts": _ts(),
+        })
 
         event = asyncio.Event()
         hitl_events[session_id] = event
@@ -69,6 +89,7 @@ async def run_qa_session(
                 "type": "session_status",
                 "status": "error",
                 "message": "HITL approval timed out",
+                "ts": _ts(),
             })
             return "error"
 
@@ -76,10 +97,13 @@ async def run_qa_session(
         hitl_events.pop(session_id, None)
 
         if decision == "skip":
-            await queue.put({"type": "session_status", "status": "skipped"})
+            await queue.put({
+                "type": "session_status",
+                "status": "skipped",
+                "ts": _ts(),
+            })
             return "skipped"
 
-        # Approved — run Coder agent
         ticket_path = project_path / ".smrt" / "tickets" / f"{ticket_id}.md"
         ticket_content = (
             ticket_path.read_text(encoding="utf-8")
@@ -92,6 +116,7 @@ async def run_qa_session(
             "type": "session_status",
             "status": "coder_running",
             "fix_attempt": attempt,
+            "ts": _ts(),
         })
         await run_coder_agent(
             project_path=project_path,
@@ -103,15 +128,19 @@ async def run_qa_session(
             pytest_output=pytest_output,
         )
 
-        # Subprocess recheck — no AI call
         recheck_output = run_pytest(project_path)
-        await queue.put({"type": "recheck_output", "output": recheck_output[:2000]})
+        await queue.put({
+            "type": "recheck_output",
+            "output": recheck_output[:2000],
+            "ts": _ts(),
+        })
 
         if "passed" in recheck_output and "failed" not in recheck_output:
             await queue.put({
                 "type": "session_status",
                 "status": "done",
                 "fix_attempt": attempt,
+                "ts": _ts(),
             })
             return "done"
 

--- a/backend/src/smrt_agent/agents/qa/loop.py
+++ b/backend/src/smrt_agent/agents/qa/loop.py
@@ -1,6 +1,7 @@
 """Anthropic SDK streaming loop for the QA agent."""
 import asyncio
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,10 @@ from smrt_agent.agents.qa.tools import (
     write_test_status, append_bugs_resolved,
 )
 from smrt_agent.agents.reviewer.tools import list_files, read_file
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _load_system_prompt() -> str:
@@ -89,7 +94,12 @@ async def run_qa_agent(
                 if hasattr(event, "type") and event.type == "content_block_delta":
                     delta = getattr(event, "delta", None)
                     if delta and getattr(delta, "type", None) == "text_delta":
-                        await queue.put({"type": "qa_text_delta", "text": delta.text})
+                        await queue.put({
+                            "type": "qa_text_delta",
+                            "text": delta.text,
+                            "agent": "qa",
+                            "ts": _ts(),
+                        })
             response = stream.get_final_message()
 
         total_input += response.usage.input_tokens
@@ -102,6 +112,7 @@ async def run_qa_agent(
                 "cost_usd": round(cost, 4),
                 "total_input_tokens": total_input,
                 "total_output_tokens": total_output,
+                "ts": _ts(),
             })
             return last_ticket_id
 
@@ -112,6 +123,7 @@ async def run_qa_agent(
                 "total_output_tokens": total_output,
                 "cost_usd": round(cost, 4),
                 "ticket_id": last_ticket_id,
+                "ts": _ts(),
             })
             return last_ticket_id
 
@@ -124,6 +136,7 @@ async def run_qa_agent(
                         "agent": "qa",
                         "tool": block.name,
                         "input": block.input,
+                        "ts": _ts(),
                     })
                     result, ticket_id = _dispatch_tool(block.name, block.input, project_path)
                     if ticket_id:
@@ -132,7 +145,8 @@ async def run_qa_agent(
                         "type": "tool_result",
                         "agent": "qa",
                         "tool": block.name,
-                        "result": result[:500],
+                        "result": result[:2000],
+                        "ts": _ts(),
                     })
                     tool_results.append({
                         "type": "tool_result",
@@ -146,5 +160,6 @@ async def run_qa_agent(
         await queue.put({
             "type": "error",
             "message": f"QA agent unexpected stop_reason: {response.stop_reason}",
+            "ts": _ts(),
         })
         return last_ticket_id

--- a/backend/src/smrt_agent/agents/reviewer/loop.py
+++ b/backend/src/smrt_agent/agents/reviewer/loop.py
@@ -1,6 +1,7 @@
 """Anthropic SDK streaming loop for the Reviewer agent."""
 import asyncio
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,10 @@ import anthropic
 
 from smrt_agent.agents.reviewer.budget import TOOL_DEFINITIONS, compute_cost_usd
 from smrt_agent.agents.reviewer.tools import fetch_url, list_files, read_file, write_file
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _load_system_prompt() -> str:
@@ -65,7 +70,12 @@ async def run_reviewer(
                 if hasattr(event, "type") and event.type == "content_block_delta":
                     delta = getattr(event, "delta", None)
                     if delta and getattr(delta, "type", None) == "text_delta":
-                        await queue.put({"type": "text_delta", "text": delta.text})
+                        await queue.put({
+                            "type": "text_delta",
+                            "text": delta.text,
+                            "agent": "reviewer",
+                            "ts": _ts(),
+                        })
 
             response = stream.get_final_message()
 
@@ -79,6 +89,7 @@ async def run_reviewer(
                 "cost_usd": round(cost, 4),
                 "total_input_tokens": total_input,
                 "total_output_tokens": total_output,
+                "ts": _ts(),
             })
             return
 
@@ -88,6 +99,7 @@ async def run_reviewer(
                 "total_input_tokens": total_input,
                 "total_output_tokens": total_output,
                 "cost_usd": round(cost, 4),
+                "ts": _ts(),
             })
             return
 
@@ -97,14 +109,18 @@ async def run_reviewer(
                 if getattr(block, "type", None) == "tool_use":
                     await queue.put({
                         "type": "tool_use",
+                        "agent": "reviewer",
                         "tool": block.name,
                         "input": block.input,
+                        "ts": _ts(),
                     })
                     result = _dispatch_tool(block.name, block.input, project_path)
                     await queue.put({
                         "type": "tool_result",
+                        "agent": "reviewer",
                         "tool": block.name,
-                        "result": result[:500],
+                        "result": result[:2000],
+                        "ts": _ts(),
                     })
                     tool_results.append({
                         "type": "tool_result",
@@ -119,5 +135,6 @@ async def run_reviewer(
         await queue.put({
             "type": "error",
             "message": f"Unexpected stop_reason: {response.stop_reason}",
+            "ts": _ts(),
         })
         return

--- a/backend/src/smrt_agent/api/qa_sessions.py
+++ b/backend/src/smrt_agent/api/qa_sessions.py
@@ -66,7 +66,7 @@ async def create_qa_session(
 
 async def _session_task(
     *, project_id: int, session_id: str, canonical_path: str,
-    queue: asyncio.Queue, api_key: str, model_qa: str, model_coder: str,
+    queue: "EventLogger", api_key: str, model_qa: str, model_coder: str,
     budget_usd: float, max_fix_attempts: int,
 ) -> None:
     final_status = "error"
@@ -131,7 +131,10 @@ async def get_qa_session_events(
     for line in log_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if line:
-            events.append(json.loads(line))
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
     return {"events": events}
 
 

--- a/backend/src/smrt_agent/api/qa_sessions.py
+++ b/backend/src/smrt_agent/api/qa_sessions.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Annotated, AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -13,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from smrt_agent.api.deps import get_db
 from smrt_agent.db.models import Project, QASession
 from smrt_agent.db.session import get_engine, get_session_factory
+from smrt_agent.event_log import EventLogger
 from smrt_agent.settings import Settings
 from smrt_agent.agents.orchestrator import run_qa_session
 
@@ -39,13 +41,19 @@ async def create_qa_session(
 
     queue: asyncio.Queue = asyncio.Queue()
     _queues[session_id] = queue
+
+    logged_queue = EventLogger(
+        queue,
+        Path(project.canonical_path) / ".smrt" / "qa-sessions" / f"{session_id}.jsonl",
+    )
+
     settings = Settings()
 
     asyncio.create_task(_session_task(
         project_id=project_id,
         session_id=session_id,
         canonical_path=project.canonical_path,
-        queue=queue,
+        queue=logged_queue,
         api_key=settings.anthropic_api_key,
         model_qa=settings.model_qa,
         model_coder=settings.model_coder,
@@ -61,7 +69,6 @@ async def _session_task(
     queue: asyncio.Queue, api_key: str, model_qa: str, model_coder: str,
     budget_usd: float, max_fix_attempts: int,
 ) -> None:
-    from pathlib import Path
     final_status = "error"
     try:
         engine = get_engine(force_new=False)
@@ -106,6 +113,26 @@ async def _session_task(
         except Exception:
             pass
         await queue.put({"type": "done", "status": final_status})
+
+
+@router.get("/{project_id}/qa-sessions/{session_id}/events")
+async def get_qa_session_events(
+    project_id: int,
+    session_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    log_path = Path(project.canonical_path) / ".smrt" / "qa-sessions" / f"{session_id}.jsonl"
+    if not log_path.exists():
+        return {"events": []}
+    events = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return {"events": events}
 
 
 @router.get("/{project_id}/qa-sessions/{session_id}/stream")

--- a/backend/src/smrt_agent/api/runs.py
+++ b/backend/src/smrt_agent/api/runs.py
@@ -69,7 +69,7 @@ async def _run_task(
     project_id: int,
     canonical_path: str,
     run_id: str,
-    queue: asyncio.Queue,
+    queue: "EventLogger",
     api_key: str,
     model: str,
     budget_usd: float,
@@ -133,7 +133,10 @@ async def get_run_events(
     for line in log_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if line:
-            events.append(json.loads(line))
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
     return {"events": events}
 
 

--- a/backend/src/smrt_agent/api/runs.py
+++ b/backend/src/smrt_agent/api/runs.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Annotated, AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -15,6 +16,7 @@ from smrt_agent.api.deps import get_db
 from smrt_agent.api.schemas import RunCreatedResponse
 from smrt_agent.db.models import AgentRun, Project
 from smrt_agent.db.session import get_engine, get_session_factory
+from smrt_agent.event_log import EventLogger
 from smrt_agent.settings import Settings
 
 router = APIRouter(prefix="/projects", tags=["runs"])
@@ -40,6 +42,11 @@ async def create_run(
     queue: asyncio.Queue = asyncio.Queue()
     _queues[run_id] = queue
 
+    logged_queue = EventLogger(
+        queue,
+        Path(project.canonical_path) / ".smrt" / "runs" / f"{run_id}.jsonl",
+    )
+
     settings = Settings()
 
     asyncio.create_task(
@@ -47,7 +54,7 @@ async def create_run(
             project_id=project_id,
             canonical_path=project.canonical_path,
             run_id=run_id,
-            queue=queue,
+            queue=logged_queue,
             api_key=settings.anthropic_api_key,
             model=settings.model_reviewer,
             budget_usd=settings.budget_per_run_usd,
@@ -67,8 +74,6 @@ async def _run_task(
     model: str,
     budget_usd: float,
 ) -> None:
-    from pathlib import Path
-
     final_status = "error"
     try:
         # Update run status to running
@@ -110,6 +115,26 @@ async def _run_task(
                     await db.commit()
         except Exception:
             pass
+
+
+@router.get("/{project_id}/runs/{run_id}/events")
+async def get_run_events(
+    project_id: int,
+    run_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    log_path = Path(project.canonical_path) / ".smrt" / "runs" / f"{run_id}.jsonl"
+    if not log_path.exists():
+        return {"events": []}
+    events = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return {"events": events}
 
 
 @router.get("/{project_id}/runs/{run_id}/stream")

--- a/backend/src/smrt_agent/api/tickets.py
+++ b/backend/src/smrt_agent/api/tickets.py
@@ -1,0 +1,37 @@
+"""Bug tickets API: list .smrt/tickets/ files for a project."""
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+
+router = APIRouter(prefix="/projects", tags=["tickets"])
+
+
+@router.get("/{project_id}/tickets")
+async def list_tickets(
+    project_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[dict]:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    tickets_dir = Path(project.canonical_path) / ".smrt" / "tickets"
+    if not tickets_dir.exists():
+        return []
+
+    results = []
+    for path in sorted(tickets_dir.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        title = lines[0].lstrip("#").strip() if lines else path.stem
+        results.append({
+            "id": path.stem,
+            "title": title,
+            "content": content,
+        })
+    return results

--- a/backend/src/smrt_agent/event_log.py
+++ b/backend/src/smrt_agent/event_log.py
@@ -1,0 +1,29 @@
+"""EventLogger: wraps asyncio.Queue and tees every put() to a JSONL file."""
+import asyncio
+import json
+from pathlib import Path
+
+
+class EventLogger:
+    """Wraps an asyncio.Queue, writing each event to a JSONL log file.
+
+    The agent loops call put() on this wrapper. The SSE endpoints read
+    directly from the inner queue. This tees events to persistent storage
+    without changing the SSE streaming path.
+    """
+
+    def __init__(self, inner: asyncio.Queue, log_path: Path) -> None:
+        self._inner = inner
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._log_path = log_path
+
+    async def put(self, item: dict) -> None:
+        with self._log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(item) + "\n")
+        await self._inner.put(item)
+
+    def empty(self) -> bool:
+        return self._inner.empty()
+
+    def get_nowait(self) -> dict:
+        return self._inner.get_nowait()

--- a/backend/src/smrt_agent/main.py
+++ b/backend/src/smrt_agent/main.py
@@ -10,6 +10,7 @@ from smrt_agent.api.projects import router as projects_router
 from smrt_agent.api.runs import router as runs_router
 from smrt_agent.api.sandbox import router as sandbox_router
 from smrt_agent.api.qa_sessions import router as qa_sessions_router
+from smrt_agent.api.tickets import router as tickets_router
 
 
 @asynccontextmanager
@@ -44,6 +45,7 @@ def create_app() -> FastAPI:
     app.include_router(sandbox_router)
     app.include_router(runs_router)
     app.include_router(qa_sessions_router)
+    app.include_router(tickets_router)
 
     return app
 

--- a/backend/tests/test_event_log.py
+++ b/backend/tests/test_event_log.py
@@ -1,0 +1,137 @@
+"""Tests for EventLogger and events replay endpoints."""
+import asyncio
+import json
+import pytest
+from pathlib import Path
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import AsyncMock, MagicMock
+
+from smrt_agent.event_log import EventLogger
+from smrt_agent.main import app
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+
+
+# ── EventLogger unit tests ──────────────────────────────────────────────────
+
+async def test_event_logger_puts_to_inner_queue(tmp_path):
+    inner: asyncio.Queue = asyncio.Queue()
+    logger = EventLogger(inner, tmp_path / "events.jsonl")
+    await logger.put({"type": "text_delta", "text": "hello"})
+    assert not inner.empty()
+    event = inner.get_nowait()
+    assert event == {"type": "text_delta", "text": "hello"}
+
+
+async def test_event_logger_writes_jsonl_file(tmp_path):
+    inner: asyncio.Queue = asyncio.Queue()
+    log_path = tmp_path / "events.jsonl"
+    logger = EventLogger(inner, log_path)
+    await logger.put({"type": "tool_use", "tool": "list_files"})
+    await logger.put({"type": "done", "cost_usd": 0.001})
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"type": "tool_use", "tool": "list_files"}
+    assert json.loads(lines[1]) == {"type": "done", "cost_usd": 0.001}
+
+
+async def test_event_logger_creates_parent_dirs(tmp_path):
+    inner: asyncio.Queue = asyncio.Queue()
+    deep_path = tmp_path / "a" / "b" / "c" / "events.jsonl"
+    logger = EventLogger(inner, deep_path)
+    await logger.put({"type": "done"})
+    assert deep_path.exists()
+
+
+# ── Replay API tests ─────────────────────────────────────────────────────────
+
+async def test_get_run_events_returns_stored_events(tmp_path):
+    """GET /projects/1/runs/run-abc/events reads the JSONL log."""
+    log_dir = tmp_path / ".smrt" / "runs"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "run-abc.jsonl"
+    log_file.write_text(
+        json.dumps({"type": "text_delta", "text": "hi"}) + "\n" +
+        json.dumps({"type": "done"}) + "\n",
+        encoding="utf-8",
+    )
+
+    async def override_db():
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tmp_path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/runs/run-abc/events")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["events"][0] == {"type": "text_delta", "text": "hi"}
+        assert data["events"][1] == {"type": "done"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_get_run_events_returns_empty_when_no_log(tmp_path):
+    async def override_db():
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tmp_path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/runs/nonexistent-run/events")
+        assert resp.status_code == 200
+        assert resp.json() == {"events": []}
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_get_run_events_404_for_unknown_project():
+    async def override_db():
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=None)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/999/runs/run-abc/events")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_get_qa_session_events_returns_stored_events(tmp_path):
+    """GET /projects/1/qa-sessions/sess-abc/events reads the JSONL log."""
+    log_dir = tmp_path / ".smrt" / "qa-sessions"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "sess-abc.jsonl"
+    log_file.write_text(
+        json.dumps({"type": "session_status", "status": "qa_running"}) + "\n",
+        encoding="utf-8",
+    )
+
+    async def override_db():
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tmp_path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/qa-sessions/sess-abc/events")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["events"][0]["type"] == "session_status"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_reviewer_loop.py
+++ b/backend/tests/test_reviewer_loop.py
@@ -140,3 +140,46 @@ async def test_run_reviewer_stops_on_budget_exceeded(project_path):
 
     types = [e["type"] for e in events]
     assert "budget_exceeded" in types
+
+
+async def test_run_reviewer_tool_events_have_ts_and_agent(project_path):
+    queue: asyncio.Queue = asyncio.Queue()
+
+    call_count = 0
+
+    def stream_side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        s = MagicMock()
+        s.__enter__ = MagicMock(return_value=s)
+        s.__exit__ = MagicMock(return_value=False)
+        s.__iter__ = MagicMock(return_value=iter([]))
+        if call_count == 1:
+            s.get_final_message = MagicMock(return_value=_make_tool_use_response("list_files", {"subdir": ""}))
+        else:
+            s.get_final_message = MagicMock(return_value=_make_end_turn_response())
+        return s
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(side_effect=stream_side_effect)
+
+    with patch("smrt_agent.agents.reviewer.loop.anthropic.Anthropic", return_value=mock_client):
+        await run_reviewer(
+            project_path=project_path,
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            budget_usd=1.50,
+            queue=queue,
+        )
+
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+
+    tool_events = [e for e in events if e["type"] in ("tool_use", "tool_result")]
+    assert len(tool_events) >= 2, "Expected at least one tool_use + tool_result pair"
+
+    for evt in tool_events:
+        assert "ts" in evt, f"Event {evt['type']} missing 'ts' field"
+        assert "agent" in evt, f"Event {evt['type']} missing 'agent' field"
+        assert evt["agent"] == "reviewer"

--- a/backend/tests/test_tickets_api.py
+++ b/backend/tests/test_tickets_api.py
@@ -1,0 +1,89 @@
+"""Tests for the bug tickets API."""
+import pytest
+from pathlib import Path
+from httpx import AsyncClient, ASGITransport
+
+from smrt_agent.main import app
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+
+
+@pytest.fixture
+def tickets_dir(tmp_path):
+    """Creates a temp project directory with two ticket files."""
+    smrt = tmp_path / ".smrt" / "tickets"
+    smrt.mkdir(parents=True)
+    (smrt / "2026-04-24-001.md").write_text(
+        "# GET /items returns 404\nDescription: endpoint missing.", encoding="utf-8"
+    )
+    (smrt / "2026-04-24-002.md").write_text(
+        "# POST /items ignores body\nDescription: input not saved.", encoding="utf-8"
+    )
+    return tmp_path
+
+
+async def test_list_tickets_returns_empty_when_no_smrt_dir(tmp_path):
+    async def override_db():
+        from unittest.mock import AsyncMock, MagicMock
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tmp_path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/projects/1/tickets")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_list_tickets_returns_files(tickets_dir):
+    async def override_db():
+        from unittest.mock import AsyncMock, MagicMock
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tickets_dir)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/projects/1/tickets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        ids = [t["id"] for t in data]
+        assert "2026-04-24-001" in ids
+        assert "2026-04-24-002" in ids
+        ticket = next(t for t in data if t["id"] == "2026-04-24-001")
+        assert ticket["title"] == "GET /items returns 404"
+        assert "Description" in ticket["content"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_list_tickets_404_for_unknown_project():
+    async def override_db():
+        from unittest.mock import AsyncMock
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=None)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/projects/999/tickets")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from './client'
+import type { AgentEvent } from '../components/AgentTimeline'
 
 export interface AgentRun {
   run_id: string
@@ -7,4 +8,9 @@ export interface AgentRun {
 
 export function createRun(projectId: number): Promise<AgentRun> {
   return apiFetch<AgentRun>(`/projects/${projectId}/runs`, { method: 'POST' })
+}
+
+export async function getRunEvents(projectId: number, runId: string): Promise<AgentEvent[]> {
+  const data = await apiFetch<{ events: AgentEvent[] }>(`/projects/${projectId}/runs/${runId}/events`)
+  return data.events
 }

--- a/frontend/src/api/tickets.ts
+++ b/frontend/src/api/tickets.ts
@@ -1,0 +1,11 @@
+import { apiFetch } from './client'
+
+export interface Ticket {
+  id: string
+  title: string
+  content: string
+}
+
+export async function listTickets(projectId: number): Promise<Ticket[]> {
+  return apiFetch<Ticket[]>(`/projects/${projectId}/tickets`)
+}

--- a/frontend/src/api/tickets.ts
+++ b/frontend/src/api/tickets.ts
@@ -6,6 +6,6 @@ export interface Ticket {
   content: string
 }
 
-export async function listTickets(projectId: number): Promise<Ticket[]> {
-  return apiFetch<Ticket[]>(`/projects/${projectId}/tickets`)
+export async function listTickets(projectId: number, signal?: AbortSignal): Promise<Ticket[]> {
+  return apiFetch<Ticket[]>(`/projects/${projectId}/tickets`, { signal })
 }

--- a/frontend/src/components/AgentTimeline.tsx
+++ b/frontend/src/components/AgentTimeline.tsx
@@ -1,0 +1,276 @@
+import { useState, useMemo } from 'react'
+
+export interface AgentEvent {
+  type: string
+  text?: string
+  tool?: string
+  agent?: string
+  input?: unknown
+  result?: string
+  message?: string
+  status?: string
+  fix_attempt?: number
+  output?: string
+  ts?: string
+  ticket_id?: string
+  total_input_tokens?: number
+  total_output_tokens?: number
+  cost_usd?: number
+}
+
+interface ToolCallPair {
+  use: AgentEvent
+  result: AgentEvent | null
+}
+
+interface AgentPhase {
+  id: string
+  label: string
+  agentType: string
+  startTs?: string
+  textEvents: AgentEvent[]
+  toolPairs: ToolCallPair[]
+  recheckEvent: AgentEvent | null
+  errorEvent: AgentEvent | null
+}
+
+function makePhaseLabel(status: string, fixAttempt?: number): string {
+  const attempt = fixAttempt !== undefined ? ` — Attempt ${fixAttempt}` : ''
+  switch (status) {
+    case 'qa_running':
+      return `QA Agent${attempt}`
+    case 'coder_running':
+      return `Coder Agent${attempt}`
+    case 'hitl_waiting':
+      return 'Awaiting Approval'
+    case 'done':
+      return 'Complete'
+    case 'error':
+      return 'Error'
+    case 'skipped':
+      return 'Skipped'
+    default:
+      return status
+  }
+}
+
+function agentFromStatus(status: string): string {
+  if (status.startsWith('coder')) return 'coder'
+  if (status.startsWith('qa')) return 'qa'
+  return 'system'
+}
+
+function groupIntoPhases(events: AgentEvent[], defaultLabel: string): AgentPhase[] {
+  const phases: AgentPhase[] = []
+  let toolUseQueue: AgentEvent[] = []
+  let current: AgentPhase = {
+    id: 'default',
+    label: defaultLabel,
+    agentType: defaultLabel.toLowerCase().includes('reviewer') ? 'reviewer' : 'qa',
+    textEvents: [],
+    toolPairs: [],
+    recheckEvent: null,
+    errorEvent: null,
+  }
+
+  for (const event of events) {
+    if (event.type === 'session_status' && event.status) {
+      toolUseQueue.forEach((use) => current.toolPairs.push({ use, result: null }))
+      toolUseQueue = []
+      if (
+        current.textEvents.length > 0 ||
+        current.toolPairs.length > 0 ||
+        current.recheckEvent ||
+        current.errorEvent
+      ) {
+        phases.push(current)
+      }
+      current = {
+        id: `${event.status}-${event.fix_attempt ?? 0}-${phases.length}`,
+        label: makePhaseLabel(event.status, event.fix_attempt),
+        agentType: agentFromStatus(event.status),
+        startTs: event.ts,
+        textEvents: [],
+        toolPairs: [],
+        recheckEvent: null,
+        errorEvent: null,
+      }
+    } else if (['text_delta', 'qa_text_delta', 'coder_text_delta'].includes(event.type)) {
+      current.textEvents.push(event)
+    } else if (event.type === 'tool_use') {
+      toolUseQueue.push(event)
+    } else if (event.type === 'tool_result') {
+      const use = toolUseQueue.shift()
+      if (use) {
+        current.toolPairs.push({ use, result: event })
+      }
+    } else if (event.type === 'recheck_output') {
+      current.recheckEvent = event
+    } else if (event.type === 'error') {
+      current.errorEvent = event
+    }
+  }
+
+  toolUseQueue.forEach((use) => current.toolPairs.push({ use, result: null }))
+  if (
+    current.textEvents.length > 0 ||
+    current.toolPairs.length > 0 ||
+    current.recheckEvent ||
+    current.errorEvent
+  ) {
+    phases.push(current)
+  }
+
+  return phases
+}
+
+const AGENT_STYLES = {
+  reviewer: {
+    header: 'bg-blue-50 border-blue-200',
+    text: 'text-blue-800',
+    border: 'border-blue-200',
+    tool: 'text-blue-700',
+  },
+  qa: {
+    header: 'bg-purple-50 border-purple-200',
+    text: 'text-purple-800',
+    border: 'border-purple-200',
+    tool: 'text-purple-700',
+  },
+  coder: {
+    header: 'bg-orange-50 border-orange-200',
+    text: 'text-orange-800',
+    border: 'border-orange-200',
+    tool: 'text-orange-700',
+  },
+  system: {
+    header: 'bg-gray-50 border-gray-200',
+    text: 'text-gray-700',
+    border: 'border-gray-200',
+    tool: 'text-gray-600',
+  },
+}
+
+function ToolCallRow({ pair }: { pair: ToolCallPair }) {
+  const [expanded, setExpanded] = useState(false)
+  const style =
+    AGENT_STYLES[pair.use.agent as keyof typeof AGENT_STYLES] ?? AGENT_STYLES.system
+
+  return (
+    <div className={`border rounded text-xs font-mono ${style.border}`}>
+      <button
+        className="w-full text-left px-3 py-1.5 flex items-center gap-2 hover:bg-gray-50"
+        onClick={() => setExpanded((p) => !p)}
+      >
+        <span className="text-gray-400 w-3 shrink-0">{expanded ? '▼' : '▶'}</span>
+        <span className={`font-semibold ${style.tool}`}>{pair.use.tool}</span>
+        {!expanded && (
+          <span className="text-gray-400 truncate">
+            {JSON.stringify(pair.use.input).slice(0, 80)}
+          </span>
+        )}
+        {pair.use.ts && (
+          <span className="ml-auto text-gray-400 shrink-0">
+            {new Date(pair.use.ts).toLocaleTimeString()}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <div className="border-t px-3 py-2 space-y-2 bg-gray-50">
+          <div>
+            <p className="text-gray-400 text-xs mb-1">Input</p>
+            <pre className="whitespace-pre-wrap text-gray-700 text-xs">
+              {JSON.stringify(pair.use.input, null, 2)}
+            </pre>
+          </div>
+          {pair.result && (
+            <div>
+              <p className="text-gray-400 text-xs mb-1">Result</p>
+              <pre className="whitespace-pre-wrap text-gray-600 text-xs max-h-48 overflow-y-auto">
+                {pair.result.result}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PhaseSection({ phase, defaultOpen }: { phase: AgentPhase; defaultOpen: boolean }) {
+  const [collapsed, setCollapsed] = useState(!defaultOpen)
+  const style =
+    AGENT_STYLES[phase.agentType as keyof typeof AGENT_STYLES] ?? AGENT_STYLES.system
+  const text = phase.textEvents.map((e) => e.text ?? '').join('')
+
+  return (
+    <div className={`border rounded overflow-hidden ${style.border}`}>
+      <button
+        className={`w-full text-left px-3 py-2 flex items-center gap-2 border-b ${style.header}`}
+        onClick={() => setCollapsed((p) => !p)}
+      >
+        <span className="text-gray-400 w-3 shrink-0">{collapsed ? '▶' : '▼'}</span>
+        <span className={`font-semibold text-sm ${style.text}`}>{phase.label}</span>
+        {phase.startTs && (
+          <span className="ml-auto text-xs text-gray-400">
+            {new Date(phase.startTs).toLocaleTimeString()}
+          </span>
+        )}
+      </button>
+      {!collapsed && (
+        <div className="p-3 space-y-2 bg-white">
+          {text && (
+            <div className="text-xs text-gray-700 leading-relaxed bg-gray-50 rounded p-2 max-h-32 overflow-y-auto">
+              {text}
+            </div>
+          )}
+          {phase.toolPairs.map((pair, i) => (
+            <ToolCallRow key={i} pair={pair} />
+          ))}
+          {phase.recheckEvent && (
+            <div>
+              <p className="text-xs text-gray-500 mb-1 font-medium">Pytest recheck</p>
+              <pre
+                className={`text-xs p-2 rounded border whitespace-pre-wrap max-h-48 overflow-y-auto ${
+                  phase.recheckEvent.output?.includes('passed') &&
+                  !phase.recheckEvent.output?.includes('failed')
+                    ? 'bg-green-50 border-green-200 text-green-800'
+                    : 'bg-red-50 border-red-200 text-red-800'
+                }`}
+              >
+                {phase.recheckEvent.output}
+              </pre>
+            </div>
+          )}
+          {phase.errorEvent && (
+            <div className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700">
+              Error: {phase.errorEvent.message}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function AgentTimeline({
+  events,
+  defaultLabel = 'Agent',
+}: {
+  events: AgentEvent[]
+  defaultLabel?: string
+}) {
+  const phases = useMemo(() => groupIntoPhases(events, defaultLabel), [events, defaultLabel])
+
+  if (phases.length === 0) {
+    return <p className="text-xs text-gray-400 italic">Waiting for events…</p>
+  }
+
+  return (
+    <div className="space-y-2">
+      {phases.map((phase) => (
+        <PhaseSection key={phase.id} phase={phase} defaultOpen={true} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/AgentTimeline.tsx
+++ b/frontend/src/components/AgentTimeline.tsx
@@ -166,7 +166,7 @@ function ToolCallRow({ pair }: { pair: ToolCallPair }) {
         <span className={`font-semibold ${style.tool}`}>{pair.use.tool}</span>
         {!expanded && (
           <span className="text-gray-400 truncate">
-            {JSON.stringify(pair.use.input).slice(0, 80)}
+            {(() => { try { return JSON.stringify(pair.use.input).slice(0, 80) } catch { return '[input]' } })()}
           </span>
         )}
         {pair.use.ts && (
@@ -180,7 +180,7 @@ function ToolCallRow({ pair }: { pair: ToolCallPair }) {
           <div>
             <p className="text-gray-400 text-xs mb-1">Input</p>
             <pre className="whitespace-pre-wrap text-gray-700 text-xs">
-              {JSON.stringify(pair.use.input, null, 2)}
+              {(() => { try { return JSON.stringify(pair.use.input, null, 2) } catch { return '[input]' } })()}
             </pre>
           </div>
           {pair.result && (
@@ -197,8 +197,8 @@ function ToolCallRow({ pair }: { pair: ToolCallPair }) {
   )
 }
 
-function PhaseSection({ phase, defaultOpen }: { phase: AgentPhase; defaultOpen: boolean }) {
-  const [collapsed, setCollapsed] = useState(!defaultOpen)
+function PhaseSection({ phase }: { phase: AgentPhase }) {
+  const [collapsed, setCollapsed] = useState(false)
   const style =
     AGENT_STYLES[phase.agentType as keyof typeof AGENT_STYLES] ?? AGENT_STYLES.system
   const text = phase.textEvents.map((e) => e.text ?? '').join('')
@@ -225,7 +225,7 @@ function PhaseSection({ phase, defaultOpen }: { phase: AgentPhase; defaultOpen: 
             </div>
           )}
           {phase.toolPairs.map((pair, i) => (
-            <ToolCallRow key={i} pair={pair} />
+            <ToolCallRow key={`${pair.use.tool}-${pair.use.ts ?? i}`} pair={pair} />
           ))}
           {phase.recheckEvent && (
             <div>
@@ -269,7 +269,7 @@ export function AgentTimeline({
   return (
     <div className="space-y-2">
       {phases.map((phase) => (
-        <PhaseSection key={phase.id} phase={phase} defaultOpen={true} />
+        <PhaseSection key={phase.id} phase={phase} />
       ))}
     </div>
   )

--- a/frontend/src/components/LiveAgentView.tsx
+++ b/frontend/src/components/LiveAgentView.tsx
@@ -1,50 +1,5 @@
 import { useEffect, useState } from 'react'
-
-interface SseEvent {
-  type: string
-  text?: string
-  tool?: string
-  input?: unknown
-  result?: string
-  message?: string
-  total_input_tokens?: number
-  total_output_tokens?: number
-  cost_usd?: number
-}
-
-function EventRow({ event }: { event: SseEvent }) {
-  switch (event.type) {
-    case 'text_delta':
-      return <span className="text-gray-800">{event.text}</span>
-
-    case 'tool_use':
-      return (
-        <div className="bg-blue-50 border border-blue-200 rounded px-3 py-1 text-sm font-mono">
-          <span className="text-blue-700 font-semibold">→ {event.tool}</span>
-          {event.input && Object.keys(event.input as object).length > 0 && (
-            <span className="text-blue-500 ml-2">{JSON.stringify(event.input)}</span>
-          )}
-        </div>
-      )
-
-    case 'tool_result':
-      return (
-        <div className="bg-gray-50 border border-gray-200 rounded px-3 py-1 text-sm font-mono text-gray-600">
-          <span className="text-gray-400">← {event.tool}:</span> {event.result}
-        </div>
-      )
-
-    case 'error':
-      return (
-        <div className="bg-red-50 border border-red-200 rounded px-3 py-1 text-sm text-red-700">
-          Error: {event.message}
-        </div>
-      )
-
-    default:
-      return null
-  }
-}
+import { AgentTimeline, type AgentEvent } from './AgentTimeline'
 
 export function LiveAgentView({
   projectId,
@@ -55,7 +10,7 @@ export function LiveAgentView({
   runId: string
   onComplete?: (status: string) => void
 }) {
-  const [events, setEvents] = useState<SseEvent[]>([])
+  const [events, setEvents] = useState<AgentEvent[]>([])
   const [done, setDone] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
 
@@ -63,7 +18,7 @@ export function LiveAgentView({
     const es = new EventSource(`/api/projects/${projectId}/runs/${runId}/stream`)
 
     es.onmessage = (e) => {
-      const event = JSON.parse(e.data) as SseEvent
+      const event = JSON.parse(e.data) as AgentEvent
       setEvents((prev) => [...prev, event])
 
       if (event.type === 'done') {
@@ -95,32 +50,10 @@ export function LiveAgentView({
     return () => es.close()
   }, [projectId, runId])
 
-  const textEvents = events.filter((e) => e.type === 'text_delta')
-  const toolEvents = events.filter((e) => e.type === 'tool_use' || e.type === 'tool_result')
-
   return (
     <div className="space-y-3">
-      {toolEvents.length > 0 && (
-        <div className="space-y-1">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Tool calls</p>
-          <div className="space-y-1">
-            {toolEvents.map((event, i) => (
-              <EventRow key={i} event={event} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {textEvents.length > 0 && (
-        <div className="border rounded p-3 bg-white text-sm leading-relaxed">
-          {textEvents.map((e, i) => (
-            <EventRow key={i} event={e} />
-          ))}
-        </div>
-      )}
-
+      <AgentTimeline events={events} defaultLabel="Reviewer" />
       {summary && <p className="text-sm text-gray-500 italic">{summary}</p>}
-
       {!done && (
         <div className="flex items-center gap-2 text-sm text-gray-400">
           <span className="animate-pulse">●</span> Agent running…

--- a/frontend/src/components/LiveAgentView.tsx
+++ b/frontend/src/components/LiveAgentView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AgentTimeline, type AgentEvent } from './AgentTimeline'
 
 export function LiveAgentView({
@@ -13,6 +13,8 @@ export function LiveAgentView({
   const [events, setEvents] = useState<AgentEvent[]>([])
   const [done, setDone] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
 
   useEffect(() => {
     const es = new EventSource(`/api/projects/${projectId}/runs/${runId}/stream`)
@@ -29,16 +31,16 @@ export function LiveAgentView({
         )
         setDone(true)
         es.close()
-        onComplete?.('done')
+        onCompleteRef.current?.('done')
       } else if (event.type === 'budget_exceeded') {
         setSummary(`Budget limit reached ($${event.cost_usd?.toFixed(4)})`)
         setDone(true)
         es.close()
-        onComplete?.('error')
+        onCompleteRef.current?.('error')
       } else if (event.type === 'error') {
         setDone(true)
         es.close()
-        onComplete?.('error')
+        onCompleteRef.current?.('error')
       }
     }
 

--- a/frontend/src/components/PastRunViewer.tsx
+++ b/frontend/src/components/PastRunViewer.tsx
@@ -5,18 +5,23 @@ import { AgentTimeline, type AgentEvent } from './AgentTimeline'
 export function PastRunViewer({ projectId, runId }: { projectId: number; runId: string }) {
   const [events, setEvents] = useState<AgentEvent[] | null>(null)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function handleView() {
     setLoading(true)
+    setError(null)
     try {
       const data = await getRunEvents(projectId, runId)
       setEvents(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load events')
     } finally {
       setLoading(false)
     }
   }
 
   if (loading) return <p className="text-xs text-gray-400 p-2">Loading events…</p>
+  if (error) return <p className="text-xs text-red-500 px-2 py-1">{error}</p>
 
   if (events !== null) {
     return (

--- a/frontend/src/components/PastRunViewer.tsx
+++ b/frontend/src/components/PastRunViewer.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { getRunEvents } from '../api/runs'
+import { AgentTimeline, type AgentEvent } from './AgentTimeline'
+
+export function PastRunViewer({ projectId, runId }: { projectId: number; runId: string }) {
+  const [events, setEvents] = useState<AgentEvent[] | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleView() {
+    setLoading(true)
+    try {
+      const data = await getRunEvents(projectId, runId)
+      setEvents(data)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (loading) return <p className="text-xs text-gray-400 p-2">Loading events…</p>
+
+  if (events !== null) {
+    return (
+      <div className="p-2">
+        <AgentTimeline events={events} defaultLabel="Reviewer" />
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={handleView}
+      className="text-xs text-blue-600 hover:underline px-2 py-1"
+    >
+      View events
+    </button>
+  )
+}

--- a/frontend/src/components/QASessionView.tsx
+++ b/frontend/src/components/QASessionView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { approveQASession, skipQASession } from '../api/qa_sessions'
 import { AgentTimeline, type AgentEvent } from './AgentTimeline'
 
@@ -14,6 +14,8 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
   const [done, setDone] = useState(false)
   const [actioning, setActioning] = useState(false)
   const [totalCost, setTotalCost] = useState(0)
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
 
   useEffect(() => {
     const es = new EventSource(`/api/projects/${projectId}/qa-sessions/${sessionId}/stream`)
@@ -34,7 +36,7 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
       if (['done', 'error', 'budget_exceeded', 'timeout'].includes(event.type)) {
         setDone(true)
         es.close()
-        onComplete?.(event.status ?? event.type)
+        onCompleteRef.current?.(event.status ?? event.type)
       }
     }
 

--- a/frontend/src/components/QASessionView.tsx
+++ b/frontend/src/components/QASessionView.tsx
@@ -1,17 +1,6 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { approveQASession, skipQASession } from '../api/qa_sessions'
-
-interface QAEvent {
-  type: string
-  text?: string
-  tool?: string
-  agent?: string
-  status?: string
-  ticket_id?: string
-  fix_attempt?: number
-  message?: string
-  output?: string
-}
+import { AgentTimeline, type AgentEvent } from './AgentTimeline'
 
 interface Props {
   projectId: number
@@ -20,17 +9,17 @@ interface Props {
 }
 
 export function QASessionView({ projectId, sessionId, onComplete }: Props) {
-  const [events, setEvents] = useState<QAEvent[]>([])
+  const [events, setEvents] = useState<AgentEvent[]>([])
   const [hitlTicket, setHitlTicket] = useState<string | null>(null)
   const [done, setDone] = useState(false)
   const [actioning, setActioning] = useState(false)
-  const bottomRef = useRef<HTMLDivElement>(null)
+  const [totalCost, setTotalCost] = useState(0)
 
   useEffect(() => {
     const es = new EventSource(`/api/projects/${projectId}/qa-sessions/${sessionId}/stream`)
 
     es.onmessage = (evt) => {
-      const event: QAEvent = JSON.parse(evt.data)
+      const event: AgentEvent = JSON.parse(evt.data)
       setEvents((prev) => [...prev, event])
 
       if (event.type === 'hitl_request' && event.ticket_id) {
@@ -38,6 +27,9 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
       }
       if (event.type === 'session_status' && event.status !== 'hitl_waiting') {
         setHitlTicket(null)
+      }
+      if (event.type === 'qa_done' || event.type === 'coder_done') {
+        setTotalCost((prev) => prev + (event.cost_usd ?? 0))
       }
       if (['done', 'error', 'budget_exceeded', 'timeout'].includes(event.type)) {
         setDone(true)
@@ -53,12 +45,6 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
 
     return () => es.close()
   }, [projectId, sessionId])
-
-  useEffect(() => {
-    if (bottomRef.current && typeof bottomRef.current.scrollIntoView === 'function') {
-      bottomRef.current.scrollIntoView({ behavior: 'smooth' })
-    }
-  }, [events])
 
   async function handleApprove() {
     setActioning(true)
@@ -81,40 +67,12 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
   }
 
   return (
-    <div className="border rounded p-4 bg-gray-50 space-y-3">
-      <div className="max-h-64 overflow-y-auto font-mono text-xs space-y-0.5">
-        {events.map((evt, i) => {
-          if (evt.type === 'qa_text_delta' || evt.type === 'coder_text_delta') {
-            return <span key={i} className="text-gray-700">{evt.text}</span>
-          }
-          if (evt.type === 'tool_use') {
-            return (
-              <div key={i} className="text-blue-600">
-                [{evt.agent}] → {evt.tool}
-              </div>
-            )
-          }
-          if (evt.type === 'session_status') {
-            return (
-              <div key={i} className="text-purple-700 font-semibold">
-                ◆ {evt.status}{evt.fix_attempt !== undefined ? ` (attempt ${evt.fix_attempt})` : ''}
-              </div>
-            )
-          }
-          if (evt.type === 'recheck_output') {
-            return (
-              <pre key={i} className="text-yellow-700 whitespace-pre-wrap">
-                {evt.output}
-              </pre>
-            )
-          }
-          if (evt.type === 'error') {
-            return <div key={i} className="text-red-600">Error: {evt.message}</div>
-          }
-          return null
-        })}
-        <div ref={bottomRef} />
-      </div>
+    <div className="space-y-3">
+      <AgentTimeline events={events} />
+
+      {totalCost > 0 && (
+        <p className="text-xs text-gray-400">Running cost: ${totalCost.toFixed(4)}</p>
+      )}
 
       {hitlTicket && !done && (
         <div className="p-3 border border-yellow-300 bg-yellow-50 rounded">
@@ -140,9 +98,7 @@ export function QASessionView({ projectId, sessionId, onComplete }: Props) {
         </div>
       )}
 
-      {done && (
-        <p className="text-xs text-gray-400">Session complete.</p>
-      )}
+      {done && <p className="text-xs text-gray-400">Session complete.</p>}
     </div>
   )
 }

--- a/frontend/src/components/TicketsPanel.tsx
+++ b/frontend/src/components/TicketsPanel.tsx
@@ -31,14 +31,16 @@ export function TicketsPanel({
   refreshKey?: number
 }) {
   const [tickets, setTickets] = useState<Ticket[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    const controller = new AbortController()
     setLoading(true)
-    listTickets(projectId)
-      .then(setTickets)
-      .catch(() => setTickets([]))
-      .finally(() => setLoading(false))
+    listTickets(projectId, controller.signal)
+      .then((data) => { if (!controller.signal.aborted) setTickets(data) })
+      .catch(() => { if (!controller.signal.aborted) setTickets([]) })
+      .finally(() => { if (!controller.signal.aborted) setLoading(false) })
+    return () => controller.abort()
   }, [projectId, refreshKey])
 
   if (loading) return <p className="text-xs text-gray-400">Loading tickets…</p>

--- a/frontend/src/components/TicketsPanel.tsx
+++ b/frontend/src/components/TicketsPanel.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { listTickets, type Ticket } from '../api/tickets'
+
+function TicketCard({ ticket }: { ticket: Ticket }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="border rounded overflow-hidden border-orange-200">
+      <button
+        className="w-full text-left px-3 py-2 flex items-center gap-2 bg-orange-50 hover:bg-orange-100"
+        onClick={() => setExpanded((p) => !p)}
+      >
+        <span className="font-mono text-xs font-medium text-orange-800">{ticket.id}</span>
+        <span className="text-sm text-orange-700 truncate ml-1">{ticket.title}</span>
+        <span className="ml-auto text-gray-400 shrink-0">{expanded ? '▼' : '▶'}</span>
+      </button>
+      {expanded && (
+        <pre className="p-3 text-xs whitespace-pre-wrap text-gray-700 bg-white font-sans leading-relaxed">
+          {ticket.content}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+export function TicketsPanel({
+  projectId,
+  refreshKey,
+}: {
+  projectId: number
+  refreshKey?: number
+}) {
+  const [tickets, setTickets] = useState<Ticket[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    listTickets(projectId)
+      .then(setTickets)
+      .catch(() => setTickets([]))
+      .finally(() => setLoading(false))
+  }, [projectId, refreshKey])
+
+  if (loading) return <p className="text-xs text-gray-400">Loading tickets…</p>
+  if (tickets.length === 0)
+    return <p className="text-xs text-gray-400 italic">No bug tickets filed.</p>
+
+  return (
+    <div className="space-y-2">
+      {tickets.map((t) => (
+        <TicketCard key={t.id} ticket={t} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -5,6 +5,8 @@ import { createRun } from '../api/runs'
 import { LiveAgentView } from '../components/LiveAgentView'
 import { createQASession } from '../api/qa_sessions'
 import { QASessionView } from '../components/QASessionView'
+import { TicketsPanel } from '../components/TicketsPanel'
+import { PastRunViewer } from '../components/PastRunViewer'
 
 function StatusBadge({ status }: { status: string }) {
   const cls =
@@ -42,6 +44,7 @@ export function ProjectDetailPage() {
   const [qaSessionId, setQaSessionId] = useState<string | null>(null)
   const [qaStatus, setQaStatus] = useState<string | null>(null)
   const [startingQA, setStartingQA] = useState(false)
+  const [ticketsRefreshKey, setTicketsRefreshKey] = useState(0)
 
   useEffect(() => {
     Promise.all([getProject(projectId), listRuns(projectId)])
@@ -82,6 +85,11 @@ export function ProjectDetailPage() {
   function handleRunComplete(status: string) {
     if (!runId) return
     setPastRuns((prev) => prev.map((r) => (r.run_id === runId ? { ...r, status } : r)))
+  }
+
+  function handleQAComplete(status: string) {
+    setQaStatus(status)
+    setTicketsRefreshKey((k) => k + 1)
   }
 
   async function handleRunQA() {
@@ -157,23 +165,30 @@ export function ProjectDetailPage() {
             </thead>
             <tbody>
               {pastRuns.map((run) => (
-                <tr key={run.run_id} className="border-t hover:bg-gray-50">
-                  <td className="px-3 py-2 font-mono text-xs text-gray-600 truncate max-w-[12rem]">
-                    {run.run_id}
-                  </td>
-                  <td className="px-3 py-2">
-                    <StatusBadge status={run.status} />
-                  </td>
-                  <td className="px-3 py-2 text-right text-gray-600">
-                    {run.total_input_tokens.toLocaleString()}
-                  </td>
-                  <td className="px-3 py-2 text-right text-gray-600">
-                    {run.total_output_tokens.toLocaleString()}
-                  </td>
-                  <td className="px-3 py-2 text-gray-400 text-xs">
-                    {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
-                  </td>
-                </tr>
+                <>
+                  <tr key={run.run_id} className="border-t hover:bg-gray-50">
+                    <td className="px-3 py-2 font-mono text-xs text-gray-600 truncate max-w-[12rem]">
+                      {run.run_id}
+                    </td>
+                    <td className="px-3 py-2">
+                      <StatusBadge status={run.status} />
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-600">
+                      {run.total_input_tokens.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-600">
+                      {run.total_output_tokens.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-gray-400 text-xs">
+                      {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
+                    </td>
+                  </tr>
+                  <tr key={`${run.run_id}-events`} className="border-t bg-gray-50">
+                    <td colSpan={5} className="px-3">
+                      <PastRunViewer projectId={projectId} runId={run.run_id} />
+                    </td>
+                  </tr>
+                </>
               ))}
             </tbody>
           </table>
@@ -205,10 +220,18 @@ export function ProjectDetailPage() {
             <QASessionView
               projectId={projectId}
               sessionId={qaSessionId}
-              onComplete={setQaStatus}
+              onComplete={handleQAComplete}
             />
           </div>
         )}
+      </div>
+
+      {/* ── Bug Tickets ── */}
+      <div className="mt-8 border-t pt-6">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+          Bug Tickets
+        </h2>
+        <TicketsPanel projectId={projectId} refreshKey={ticketsRefreshKey} />
       </div>
     </div>
   )

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { getProject, listRuns, type Project, type AgentRunSummary } from '../api/projects'
 import { createRun } from '../api/runs'
@@ -165,8 +165,8 @@ export function ProjectDetailPage() {
             </thead>
             <tbody>
               {pastRuns.map((run) => (
-                <>
-                  <tr key={run.run_id} className="border-t hover:bg-gray-50">
+                <React.Fragment key={run.run_id}>
+                  <tr className="border-t hover:bg-gray-50">
                     <td className="px-3 py-2 font-mono text-xs text-gray-600 truncate max-w-[12rem]">
                       {run.run_id}
                     </td>
@@ -183,12 +183,12 @@ export function ProjectDetailPage() {
                       {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
                     </td>
                   </tr>
-                  <tr key={`${run.run_id}-events`} className="border-t bg-gray-50">
+                  <tr className="border-t bg-gray-50">
                     <td colSpan={5} className="px-3">
                       <PastRunViewer projectId={projectId} runId={run.run_id} />
                     </td>
                   </tr>
-                </>
+                </React.Fragment>
               ))}
             </tbody>
           </table>

--- a/frontend/src/test/AgentTimeline.test.tsx
+++ b/frontend/src/test/AgentTimeline.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AgentTimeline, type AgentEvent } from '../components/AgentTimeline'
+
+describe('AgentTimeline', () => {
+  it('shows waiting message with empty event array', () => {
+    render(<AgentTimeline events={[]} />)
+    expect(screen.getByText(/waiting for events/i)).toBeInTheDocument()
+  })
+
+  it('renders text delta content in a phase', () => {
+    const events: AgentEvent[] = [
+      { type: 'text_delta', text: 'Analyzing code structure…', agent: 'reviewer' },
+    ]
+    render(<AgentTimeline events={events} defaultLabel="Reviewer" />)
+    expect(screen.getByText(/Analyzing code structure…/)).toBeInTheDocument()
+  })
+
+  it('shows tool name in collapsed tool call row', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool_use', tool: 'list_files', input: { subdir: '' }, agent: 'reviewer' },
+      { type: 'tool_result', tool: 'list_files', result: '["main.py"]', agent: 'reviewer' },
+    ]
+    render(<AgentTimeline events={events} defaultLabel="Reviewer" />)
+    expect(screen.getByText(/list_files/)).toBeInTheDocument()
+  })
+
+  it('expands a tool call to show input and result', async () => {
+    const user = userEvent.setup()
+    const events: AgentEvent[] = [
+      {
+        type: 'tool_use',
+        tool: 'read_file',
+        input: { path: 'src/main.py' },
+        agent: 'reviewer',
+        ts: '2026-04-24T12:00:00.000Z',
+      },
+      {
+        type: 'tool_result',
+        tool: 'read_file',
+        result: 'from fastapi import FastAPI',
+        agent: 'reviewer',
+        ts: '2026-04-24T12:00:01.000Z',
+      },
+    ]
+    render(<AgentTimeline events={events} defaultLabel="Reviewer" />)
+    await user.click(screen.getByText(/read_file/))
+    expect(screen.getByText(/src\/main\.py/)).toBeInTheDocument()
+    expect(screen.getByText(/from fastapi import FastAPI/)).toBeInTheDocument()
+  })
+
+  it('renders separate phases for qa_running and coder_running session_status events', () => {
+    const ts = new Date().toISOString()
+    const events: AgentEvent[] = [
+      { type: 'session_status', status: 'qa_running', fix_attempt: 0, ts },
+      { type: 'qa_text_delta', text: 'Running QA tests…', agent: 'qa' },
+      { type: 'session_status', status: 'coder_running', fix_attempt: 0, ts },
+      { type: 'coder_text_delta', text: 'Fixing the bug…', agent: 'coder' },
+    ]
+    render(<AgentTimeline events={events} />)
+    expect(screen.getByText(/QA Agent/)).toBeInTheDocument()
+    expect(screen.getByText(/Coder Agent/)).toBeInTheDocument()
+    expect(screen.getByText(/Running QA tests…/)).toBeInTheDocument()
+    expect(screen.getByText(/Fixing the bug…/)).toBeInTheDocument()
+  })
+
+  it('renders recheck_output in a code block with green styling when tests pass', () => {
+    const ts = new Date().toISOString()
+    const events: AgentEvent[] = [
+      { type: 'session_status', status: 'coder_running', fix_attempt: 0, ts },
+      { type: 'recheck_output', output: '2 passed in 0.5s', ts },
+    ]
+    render(<AgentTimeline events={events} />)
+    expect(screen.getByText(/2 passed in 0\.5s/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/AgentTimeline.test.tsx
+++ b/frontend/src/test/AgentTimeline.test.tsx
@@ -72,6 +72,8 @@ describe('AgentTimeline', () => {
       { type: 'recheck_output', output: '2 passed in 0.5s', ts },
     ]
     render(<AgentTimeline events={events} />)
-    expect(screen.getByText(/2 passed in 0\.5s/)).toBeInTheDocument()
+    const pre = screen.getByText(/2 passed in 0\.5s/)
+    expect(pre).toBeInTheDocument()
+    expect(pre).toHaveClass('bg-green-50')
   })
 })

--- a/frontend/src/test/LiveAgentView.test.tsx
+++ b/frontend/src/test/LiveAgentView.test.tsx
@@ -84,6 +84,7 @@ describe('LiveAgentView', () => {
       })
     })
     expect(screen.getByText(/list_files/i)).toBeInTheDocument()
+    expect(screen.queryByText(/src\/main\.py/i)).not.toBeInTheDocument()
     await user.click(screen.getByText(/list_files/i))
     expect(screen.getByText(/src\/main\.py/i)).toBeInTheDocument()
   })

--- a/frontend/src/test/LiveAgentView.test.tsx
+++ b/frontend/src/test/LiveAgentView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { LiveAgentView } from '../components/LiveAgentView'
 
 class MockEventSource {
@@ -43,28 +44,47 @@ describe('LiveAgentView', () => {
   it('renders text_delta events', () => {
     render(<LiveAgentView projectId={1} runId="run-abc-123" />)
     act(() => {
-      MockEventSource.instance?.emit({ type: 'text_delta', text: 'Analyzing source tree…' })
+      MockEventSource.instance?.emit({
+        type: 'text_delta',
+        text: 'Analyzing source tree…',
+        agent: 'reviewer',
+      })
     })
     expect(screen.getByText('Analyzing source tree…')).toBeInTheDocument()
   })
 
-  it('renders tool_use events', () => {
+  it('renders tool_use events showing tool name', () => {
     render(<LiveAgentView projectId={1} runId="run-abc-123" />)
     act(() => {
-      MockEventSource.instance?.emit({ type: 'tool_use', tool: 'list_files', input: {} })
+      MockEventSource.instance?.emit({
+        type: 'tool_use',
+        tool: 'list_files',
+        input: {},
+        agent: 'reviewer',
+      })
     })
     expect(screen.getByText(/list_files/i)).toBeInTheDocument()
   })
 
-  it('renders tool_result events', () => {
+  it('shows tool result after expanding a tool call row', async () => {
+    const user = userEvent.setup()
     render(<LiveAgentView projectId={1} runId="run-abc-123" />)
     act(() => {
+      MockEventSource.instance?.emit({
+        type: 'tool_use',
+        tool: 'list_files',
+        input: { subdir: '' },
+        agent: 'reviewer',
+      })
       MockEventSource.instance?.emit({
         type: 'tool_result',
         tool: 'list_files',
         result: 'src/main.py',
+        agent: 'reviewer',
       })
     })
+    expect(screen.getByText(/list_files/i)).toBeInTheDocument()
+    await user.click(screen.getByText(/list_files/i))
     expect(screen.getByText(/src\/main\.py/i)).toBeInTheDocument()
   })
 

--- a/frontend/src/test/PastRunViewer.test.tsx
+++ b/frontend/src/test/PastRunViewer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { PastRunViewer } from '../components/PastRunViewer'
@@ -32,12 +32,14 @@ describe('PastRunViewer', () => {
     expect(screen.queryByRole('button', { name: /view events/i })).not.toBeInTheDocument()
   })
 
-  it('hides button after events load', async () => {
+  it('shows error message when fetch fails', async () => {
     const user = userEvent.setup()
-    vi.spyOn(runsApi, 'getRunEvents').mockResolvedValue([])
+    vi.spyOn(runsApi, 'getRunEvents').mockRejectedValue(new Error('500 Internal Server Error'))
     render(<PastRunViewer projectId={1} runId="run-abc" />)
     await user.click(screen.getByRole('button', { name: /view events/i }))
-    await waitFor(() => screen.getByTestId('agent-timeline'))
+    await waitFor(() =>
+      expect(screen.getByText(/500 Internal Server Error/i)).toBeInTheDocument()
+    )
     expect(screen.queryByRole('button', { name: /view events/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/PastRunViewer.test.tsx
+++ b/frontend/src/test/PastRunViewer.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PastRunViewer } from '../components/PastRunViewer'
+import * as runsApi from '../api/runs'
+
+vi.mock('../components/AgentTimeline', () => ({
+  AgentTimeline: ({ events }: { events: unknown[] }) => (
+    <div data-testid="agent-timeline">events:{events.length}</div>
+  ),
+}))
+
+describe('PastRunViewer', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('shows View events button initially', () => {
+    render(<PastRunViewer projectId={1} runId="run-abc" />)
+    expect(screen.getByRole('button', { name: /view events/i })).toBeInTheDocument()
+  })
+
+  it('fetches and renders events when button clicked', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(runsApi, 'getRunEvents').mockResolvedValue([
+      { type: 'text_delta', text: 'hello', agent: 'reviewer' },
+    ])
+    render(<PastRunViewer projectId={1} runId="run-abc" />)
+    await user.click(screen.getByRole('button', { name: /view events/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-timeline')).toBeInTheDocument()
+    )
+    expect(screen.getByText(/events:1/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /view events/i })).not.toBeInTheDocument()
+  })
+
+  it('hides button after events load', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(runsApi, 'getRunEvents').mockResolvedValue([])
+    render(<PastRunViewer projectId={1} runId="run-abc" />)
+    await user.click(screen.getByRole('button', { name: /view events/i }))
+    await waitFor(() => screen.getByTestId('agent-timeline'))
+    expect(screen.queryByRole('button', { name: /view events/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/ProjectDetailPage.test.tsx
+++ b/frontend/src/test/ProjectDetailPage.test.tsx
@@ -1,32 +1,50 @@
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ProjectDetailPage } from '../pages/ProjectDetailPage'
 
-// Stub EventSource so LiveAgentView doesn't crash in jsdom
-class NoopEventSource {
-  onmessage: null = null
-  onerror: null = null
-  constructor(_url: string) {}
-  close() {}
-}
-vi.stubGlobal('EventSource', NoopEventSource)
+vi.mock('../components/LiveAgentView', () => ({
+  LiveAgentView: ({ runId }: { runId: string }) => (
+    <div data-testid="live-agent-view">LiveAgentView:{runId}</div>
+  ),
+}))
 
-const mockProject = {
-  id: 1,
-  name: 'todo-api',
-  canonical_path: '/workspace/eval-fixtures/todo-api',
-  created_at: '2026-04-24T00:00:00Z',
-}
+vi.mock('../components/QASessionView', () => ({
+  QASessionView: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="qa-session-view">QASessionView:{sessionId}</div>
+  ),
+}))
+
+vi.mock('../components/TicketsPanel', () => ({
+  TicketsPanel: ({ projectId }: { projectId: number }) => (
+    <div data-testid="tickets-panel">TicketsPanel:{projectId}</div>
+  ),
+}))
+
+vi.mock('../components/PastRunViewer', () => ({
+  PastRunViewer: ({ runId }: { runId: string }) => (
+    <div data-testid="past-run-viewer">PastRunViewer:{runId}</div>
+  ),
+}))
 
 const server = setupServer(
-  http.get('http://localhost/api/projects/1', () => HttpResponse.json(mockProject)),
+  http.get('http://localhost/api/projects/1', () =>
+    HttpResponse.json({
+      id: 1,
+      name: 'todo-api',
+      canonical_path: '/d/projects/todo-api',
+      created_at: '2026-04-24T00:00:00Z',
+    }),
+  ),
   http.get('http://localhost/api/projects/1/runs', () => HttpResponse.json([])),
   http.post('http://localhost/api/projects/1/runs', () =>
-    HttpResponse.json({ run_id: 'test-run-uuid-1234', status: 'pending' }, { status: 202 }),
+    HttpResponse.json({ run_id: 'run-xyz', status: 'pending' }, { status: 202 }),
+  ),
+  http.post('http://localhost/api/projects/1/qa-sessions', () =>
+    HttpResponse.json({ session_id: 'sess-xyz', status: 'pending' }, { status: 202 }),
   ),
 )
 
@@ -34,9 +52,9 @@ beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
-function renderDetailPage(id = '1') {
+function renderPage() {
   return render(
-    <MemoryRouter initialEntries={[`/projects/${id}`]}>
+    <MemoryRouter initialEntries={['/projects/1']}>
       <Routes>
         <Route path="/projects/:id" element={<ProjectDetailPage />} />
       </Routes>
@@ -45,63 +63,67 @@ function renderDetailPage(id = '1') {
 }
 
 describe('ProjectDetailPage', () => {
-  it('shows loading then project name', async () => {
-    renderDetailPage()
-    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  it('shows project name after loading', async () => {
+    renderPage()
     await waitFor(() => expect(screen.getByText('todo-api')).toBeInTheDocument())
   })
 
-  it('shows canonical path', async () => {
-    renderDetailPage()
-    await waitFor(() =>
-      expect(screen.getByText('/workspace/eval-fixtures/todo-api')).toBeInTheDocument(),
-    )
-  })
-
   it('shows Run Init Audit button', async () => {
-    renderDetailPage()
+    renderPage()
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /run init audit/i })).toBeInTheDocument(),
     )
   })
 
-  it('starts a run when button is clicked and shows run id', async () => {
+  it('shows LiveAgentView after clicking Run Init Audit', async () => {
     const user = userEvent.setup()
-    renderDetailPage()
+    renderPage()
     await waitFor(() => screen.getByRole('button', { name: /run init audit/i }))
     await user.click(screen.getByRole('button', { name: /run init audit/i }))
-    await waitFor(() => expect(screen.getAllByText(/test-run-uuid-1234/i).length).toBeGreaterThan(0))
+    await waitFor(() =>
+      expect(screen.getByTestId('live-agent-view')).toBeInTheDocument(),
+    )
   })
-})
 
-import { createQASession } from '../api/qa_sessions'
+  it('shows Run QA Session button', async () => {
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /run qa session/i })).toBeInTheDocument(),
+    )
+  })
 
-it('qa_sessions api module exports createQASession', () => {
-  expect(typeof createQASession).toBe('function')
-})
+  it('starts a QA session when button clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /run qa session/i }))
+    await user.click(screen.getByRole('button', { name: /run qa session/i }))
+    await waitFor(() => expect(screen.getByTestId('qa-session-view')).toBeInTheDocument())
+  })
 
-vi.mock('../components/QASessionView', () => ({
-  QASessionView: ({ sessionId }: { sessionId: string }) => (
-    <div data-testid="qa-view">{sessionId}</div>
-  ),
-}))
+  it('renders the TicketsPanel section', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('tickets-panel')).toBeInTheDocument())
+  })
 
-it('shows Run QA Session button', async () => {
-  renderDetailPage()
-  await waitFor(() =>
-    expect(screen.getByRole('button', { name: /run qa session/i })).toBeInTheDocument()
-  )
-})
-
-it('starts a QA session when button clicked', async () => {
-  server.use(
-    http.post('http://localhost/api/projects/1/qa-sessions', () =>
-      HttpResponse.json({ session_id: 'qa-sess-uuid-5678', status: 'pending' }, { status: 202 }),
-    ),
-  )
-  const user = userEvent.setup()
-  renderDetailPage()
-  await waitFor(() => screen.getByRole('button', { name: /run qa session/i }))
-  await user.click(screen.getByRole('button', { name: /run qa session/i }))
-  await waitFor(() => expect(screen.getByTestId('qa-view')).toBeInTheDocument())
+  it('shows PastRunViewer in run history when past runs exist', async () => {
+    server.use(
+      http.get('http://localhost/api/projects/1/runs', () =>
+        HttpResponse.json([
+          {
+            id: 1,
+            run_id: 'run-old-123',
+            project_id: 1,
+            status: 'done',
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            started_at: '2026-04-24T00:00:00Z',
+            completed_at: '2026-04-24T00:01:00Z',
+          },
+        ]),
+      ),
+    )
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('past-run-viewer')).toBeInTheDocument())
+    expect(screen.getByText(/PastRunViewer:run-old-123/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/test/ProjectDetailPage.test.tsx
+++ b/frontend/src/test/ProjectDetailPage.test.tsx
@@ -13,14 +13,17 @@ vi.mock('../components/LiveAgentView', () => ({
 }))
 
 vi.mock('../components/QASessionView', () => ({
-  QASessionView: ({ sessionId }: { sessionId: string }) => (
-    <div data-testid="qa-session-view">QASessionView:{sessionId}</div>
+  QASessionView: ({ sessionId, onComplete }: { sessionId: string; onComplete?: (status: string) => void }) => (
+    <div data-testid="qa-session-view">
+      QASessionView:{sessionId}
+      <button onClick={() => onComplete?.('done')}>complete-qa</button>
+    </div>
   ),
 }))
 
 vi.mock('../components/TicketsPanel', () => ({
-  TicketsPanel: ({ projectId }: { projectId: number }) => (
-    <div data-testid="tickets-panel">TicketsPanel:{projectId}</div>
+  TicketsPanel: ({ projectId, refreshKey }: { projectId: number; refreshKey?: number }) => (
+    <div data-testid="tickets-panel">TicketsPanel:{projectId}:{refreshKey ?? 0}</div>
   ),
 }))
 
@@ -103,6 +106,19 @@ describe('ProjectDetailPage', () => {
   it('renders the TicketsPanel section', async () => {
     renderPage()
     await waitFor(() => expect(screen.getByTestId('tickets-panel')).toBeInTheDocument())
+  })
+
+  it('increments ticketsRefreshKey when QA session completes', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /run qa session/i }))
+    await user.click(screen.getByRole('button', { name: /run qa session/i }))
+    await waitFor(() => screen.getByTestId('qa-session-view'))
+    expect(screen.getByText(/TicketsPanel:1:0/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /complete-qa/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/TicketsPanel:1:1/)).toBeInTheDocument()
+    )
   })
 
   it('shows PastRunViewer in run history when past runs exist', async () => {

--- a/frontend/src/test/QASessionView.test.tsx
+++ b/frontend/src/test/QASessionView.test.tsx
@@ -107,8 +107,8 @@ describe('QASessionView', () => {
     ]
     render(<QASessionView projectId={1} sessionId="sess-1" />)
     await waitFor(() => screen.getByText(/list_files/))
+    expect(screen.queryByText(/\["main\.py"\]/)).not.toBeInTheDocument()
     await user.click(screen.getByText(/list_files/))
-    expect(screen.getByText(/subdir/)).toBeInTheDocument()
-    expect(screen.getByText(/main\.py/)).toBeInTheDocument()
+    expect(screen.getByText(/\["main\.py"\]/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/QASessionView.test.tsx
+++ b/frontend/src/test/QASessionView.test.tsx
@@ -96,4 +96,19 @@ describe('QASessionView', () => {
     render(<QASessionView projectId={1} sessionId="sess-1" />)
     await waitFor(() => expect(screen.getByText(/session complete/i)).toBeInTheDocument())
   })
+
+  it('shows tool input after expanding a tool call in the timeline', async () => {
+    const user = userEvent.setup()
+    _sseScenario = [
+      { type: 'session_status', status: 'qa_running', fix_attempt: 0, ts: new Date().toISOString() },
+      { type: 'tool_use', tool: 'list_files', input: { subdir: '' }, agent: 'qa' },
+      { type: 'tool_result', tool: 'list_files', result: '["main.py"]', agent: 'qa' },
+      { type: 'done', status: 'done' },
+    ]
+    render(<QASessionView projectId={1} sessionId="sess-1" />)
+    await waitFor(() => screen.getByText(/list_files/))
+    await user.click(screen.getByText(/list_files/))
+    expect(screen.getByText(/subdir/)).toBeInTheDocument()
+    expect(screen.getByText(/main\.py/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/test/TicketsPanel.test.tsx
+++ b/frontend/src/test/TicketsPanel.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { TicketsPanel } from '../components/TicketsPanel'
+
+const mockTickets = [
+  {
+    id: '2026-04-24-001',
+    title: 'GET /items returns 404',
+    content: '# GET /items returns 404\nThe endpoint is missing from the router.',
+  },
+  {
+    id: '2026-04-24-002',
+    title: 'POST /items ignores body',
+    content: '# POST /items ignores body\nInput data is discarded.',
+  },
+]
+
+const server = setupServer(
+  http.get('http://localhost/api/projects/1/tickets', () =>
+    HttpResponse.json(mockTickets),
+  ),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('TicketsPanel', () => {
+  it('shows no-tickets message when the list is empty', async () => {
+    server.use(
+      http.get('http://localhost/api/projects/1/tickets', () => HttpResponse.json([])),
+    )
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() =>
+      expect(screen.getByText(/no bug tickets/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('lists ticket IDs and titles', async () => {
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() => expect(screen.getByText('2026-04-24-001')).toBeInTheDocument())
+    expect(screen.getByText(/GET \/items returns 404/)).toBeInTheDocument()
+    expect(screen.getByText('2026-04-24-002')).toBeInTheDocument()
+  })
+
+  it('expands a ticket to show full content when clicked', async () => {
+    const user = userEvent.setup()
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() => screen.getByText('2026-04-24-001'))
+    await user.click(screen.getByText('2026-04-24-001'))
+    expect(screen.getByText(/The endpoint is missing from the router/)).toBeInTheDocument()
+  })
+
+  it('re-fetches when refreshKey changes', async () => {
+    const { rerender } = render(<TicketsPanel projectId={1} refreshKey={0} />)
+    await waitFor(() => screen.getByText('2026-04-24-001'))
+
+    server.use(
+      http.get('http://localhost/api/projects/1/tickets', () =>
+        HttpResponse.json([
+          { id: '2026-04-24-003', title: 'New ticket', content: '# New ticket\nNew content.' },
+        ]),
+      ),
+    )
+
+    rerender(<TicketsPanel projectId={1} refreshKey={1} />)
+    await waitFor(() => expect(screen.getByText('2026-04-24-003')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/test/TicketsPanel.test.tsx
+++ b/frontend/src/test/TicketsPanel.test.tsx
@@ -50,6 +50,7 @@ describe('TicketsPanel', () => {
     const user = userEvent.setup()
     render(<TicketsPanel projectId={1} />)
     await waitFor(() => screen.getByText('2026-04-24-001'))
+    expect(screen.queryByText(/The endpoint is missing from the router/)).not.toBeInTheDocument()
     await user.click(screen.getByText('2026-04-24-001'))
     expect(screen.getByText(/The endpoint is missing from the router/)).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

- **AgentTimeline component**: Phase-grouped, collapsible SSE event display with expandable tool call rows showing full input + result. Shared across `LiveAgentView` and `QASessionView`.
- **Backend SSE enrichment**: All events carry `ts` (ISO timestamp) and `agent` label; tool results truncated to 2000 chars.
- **Bug Tickets panel**: `GET /projects/{id}/tickets` backend endpoint + `TicketsPanel` frontend component listing filed tickets with expandable content. Auto-refreshes when a QA session completes.
- **Event persistence + history viewer**: `EventLogger` tees all SSE events to JSONL files. Replay endpoints at `/runs/{id}/events` and `/qa-sessions/{id}/events`. `PastRunViewer` in the run history table loads stored events on demand.
- **ProjectDetailPage integration**: Bug Tickets section, PastRunViewer companion rows per run, `ticketsRefreshKey` wired to QA completion.

## Test plan

- [ ] Backend: `docker exec smrt-llm-dev-backend-1 python -m pytest -v` → 95/95 pass
- [ ] Frontend: `cd frontend && npm test -- --run` → 37/37 pass
- [ ] TypeScript: `cd frontend && npx tsc --noEmit` → no errors
- [ ] Manual: Start a run, verify AgentTimeline shows phase sections with expandable tool calls
- [ ] Manual: Run QA session, verify Bug Tickets panel populates after completion
- [ ] Manual: Click "View events" on a past run row, verify stored event timeline renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared, phase-grouped AgentTimeline for live and historical agent/QA sessions, enrich and persist SSE events for replay, and expose project bug tickets in the UI and API.

New Features:
- Add a reusable AgentTimeline component to visualize agent and QA session events with grouped phases and expandable tool call details.
- Add PastRunViewer to load and display stored run events from a new /projects/{id}/runs/{run_id}/events endpoint.
- Add TicketsPanel and corresponding /projects/{id}/tickets endpoint to list and inspect project bug tickets from .smrt/tickets.
- Expose QA session event history via /projects/{id}/qa-sessions/{session_id}/events for later replay.

Enhancements:
- Refactor LiveAgentView and QASessionView to use the shared AgentTimeline and track additional metadata such as agent labels, timestamps, and cumulative QA cost.
- Enrich reviewer, coder, and QA backend events with timestamps, agent identifiers, and longer tool results, and propagate session status phases for better frontend grouping.
- Plug the tickets API router into the FastAPI app and integrate bug tickets and past run viewers into ProjectDetailPage.

Tests:
- Add unit and API tests for EventLogger and the new run and QA session event history endpoints.
- Add tests for the tickets API and TicketsPanel, including refresh behavior after QA completion.
- Update LiveAgentView and QASessionView tests for the new timeline behavior and tool expansion, and extend ProjectDetailPage tests for the new child components.