### PR TITLE
M7: Submission polish — README, docs, Config/Tests tabs, secret guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# SMRT Agent (`smrt-llm-dev`)
+# SMRT Agent
 
-> A semi-autonomous multi-agent system that acts as a **QA engineer + junior developer pair** inside a Python FastAPI codebase. Discovers bugs (especially logical ones), fixes them through a blackbox QA↔Coder loop, and maintains documentation in both GitHub-native Markdown and a parallel Obsidian vault.
+A semi-autonomous multi-agent system that discovers logical bugs in Python FastAPI codebases, fixes them through a blackbox QA↔Coder loop, and maintains documentation in GitHub Markdown and Obsidian vault format.
 
-**Status:** Planning phase. Spec written; implementation begins after the design + plan review gates.
+---
 
-**Spec documents:**
-- [`PRODUCTION.md`](./PRODUCTION.md) — v1 product spec (the "what" and "why")
-- [`NEXT_ITERATION.md`](./NEXT_ITERATION.md) — v2 backlog
-- [`docs/superpowers/specs/2026-04-23-smrt-llm-dev-design.md`](./docs/superpowers/specs/2026-04-23-smrt-llm-dev-design.md) — implementation design (the "how")
+## Demo — under 3 minutes
 
-## Quick start (when implementation lands)
+> Uses the bundled `eval-fixtures/todo-api` (5 intentional bugs). No external repo needed.
+
+### 1. Clone and configure
 
 ```bash
 git clone https://github.com/chlgustjr41/smrt-llm-dev
@@ -20,26 +19,125 @@ cp .env.example .env
 
 # Windows
 copy .env.example .env
+```
 
-# Edit .env and set your real ANTHROPIC_API_KEY
+Open `.env` and replace `sk-ant-api03-REPLACE_ME` with your real Anthropic API key.
 
+### 2. Start the stack
+
+```bash
 docker compose up
 ```
 
-Open http://127.0.0.1:5173 in your browser.
+Wait for both services to report ready (roughly 20–30 seconds on first run).
 
-## Requirements
+### 3. Register the demo project
 
-- **Docker Desktop** (Windows / macOS) or Docker Engine (Linux)
-  - On Windows, Docker Desktop must use the WSL2 backend
-- **Python 3.11+**
-- **Node 20+**
-- **`git`** on PATH
-- **Anthropic API key** — get one at https://console.anthropic.com/settings/keys
+Open **http://127.0.0.1:5173** in your browser.
+
+- Click **Register Project**
+- Set the project path to `/workspace/eval-fixtures/todo-api`
+- Give it any name (e.g. `todo-api`) and click **Save**
+
+> The backend container mounts the repo root at `/workspace`, so this path resolves to `eval-fixtures/todo-api` inside the repo.
+
+### 4. Run the agents
+
+- Click **Init Audit** — the Reviewer agent reads the codebase, writes `Project.md`, and generates `docs/` and `wiki/` documentation
+- Click **Find Bugs** — the QA agent writes pytest tests, runs them in an isolated Docker sandbox, and creates bug tickets
+- **Confirm** the tickets that appear in the UI (human-in-the-loop gate)
+- Watch the **Coder** agent fix each bug; approve the resulting PRs one at a time
+
+The **AgentTimeline** panel streams live thoughts for each agent. Toggle **Show reasoning** to see intermediate steps.
+
+### 5. Inspect results
+
+- **Cost dashboard** — token and USD breakdown per agent and per run
+- **Bug heatmap** — files ranked by defect density
+- **Doc completeness** — coverage score across the generated docs
+- Each PR commit carries a `[smrt-provenance]` JSON trailer explaining why the fix was applied
+
+Expected findings in `todo-api`: password hash returned in API response, missing `await` on async DB call, authorization checked after the resource is deleted, `due_at` accepted as a past timestamp, and a race condition in the completion toggle.
+
+---
+
+## What it does
+
+| Agent | Role |
+|-------|------|
+| **Reviewer** | Reads source, writes `Project.md`, generates API docs and Obsidian wiki |
+| **QA** | Writes and runs pytest tests in a sandboxed container; opens bug tickets |
+| **Coder** | Implements fixes proposed by QA; never sees the tests (blackbox loop) |
+
+The QA↔Coder loop repeats up to `SMRT_MAX_FIX_ATTEMPTS` times (default 5). If QA still rejects after the cap, the ticket is escalated for human review.
+
+Human gates exist at two points: confirming bug tickets before fixes begin, and approving each PR before it is merged.
+
+---
 
 ## Architecture
 
-See `PRODUCTION.md` §2 (agent hierarchy) and `docs/superpowers/specs/2026-04-23-smrt-llm-dev-design.md` (implementation phases).
+```
+Browser (React/Vite :5173)
+        │  REST + SSE
+        ▼
+Backend (FastAPI :8000)
+        │
+        ├── Reviewer agent ──► reads /workspace/<project>
+        │                       writes docs/ and wiki/
+        │
+        ├── QA agent ────────► generates pytest suite
+        │        ▲              runs in Docker sandbox
+        │        │ accept/reject
+        └── Coder agent ─────► patches source files
+                                opens PR (branch + diff)
+```
+
+All agents call the Anthropic Claude API. Budget guardrails (`SMRT_BUDGET_PER_RUN_USD`, `SMRT_BUDGET_PER_DAY_USD`) hard-halt any run that exceeds the configured limits.
+
+---
+
+## Requirements
+
+- **Docker Desktop** with the WSL2 backend enabled (Windows) or Docker Engine (Linux/macOS)
+- **Anthropic API key** — get one at https://console.anthropic.com/settings/keys
+- 4 GB RAM available to Docker (the sandbox container needs headroom)
+
+Python, Node, and all other dependencies are installed inside the containers. Nothing needs to be installed on the host beyond Docker.
+
+---
+
+## Configuration
+
+Copy `.env.example` to `.env`. Key variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | *(required)* | Claude API key |
+| `SMRT_BUDGET_PER_RUN_USD` | `1.50` | Hard spend cap per agent run |
+| `SMRT_BUDGET_PER_DAY_USD` | `10.00` | Hard daily spend cap per project |
+| `SMRT_MODEL_REVIEWER` | `claude-opus-4-7` | Model used by the Reviewer |
+| `SMRT_MODEL_QA` | `claude-sonnet-4-6` | Model used by QA |
+| `SMRT_MODEL_CODER` | `claude-sonnet-4-6` | Model used by Coder |
+| `SMRT_MAX_FIX_ATTEMPTS` | `5` | QA↔Coder loop cap before escalation |
+| `SMRT_BIND_HOST` | `127.0.0.1` | Bind address (localhost only by default) |
+
+All model and loop settings can also be overridden per-project in the UI.
+
+---
+
+## Troubleshooting
+
+**`docker compose up` exits immediately with a port conflict**
+Another process is using port 8000 or 5173. Change `SMRT_BACKEND_PORT` and `SMRT_FRONTEND_PORT` in `.env`, then re-run.
+
+**Init Audit finishes but no docs appear**
+The project path must be an absolute path as seen by the backend container. For the bundled demo the correct path is `/workspace/eval-fixtures/todo-api`. For your own repo, mount it and use the corresponding `/workspace/...` path.
+
+**"Anthropic API error 401"**
+The `ANTHROPIC_API_KEY` in `.env` is missing or still set to the placeholder. Replace it with a real key and restart with `docker compose restart backend`.
+
+---
 
 ## License
 

--- a/backend/src/smrt_agent/agents/coder/tools.py
+++ b/backend/src/smrt_agent/agents/coder/tools.py
@@ -2,12 +2,16 @@
 from pathlib import Path
 
 from smrt_agent.agents.reviewer.tools import _SECRET_SPEC
+from smrt_agent.hooks.secret_guard import is_blocked
 
 _BLOCKED_DIRS = {".smrt", "tests", "docs"}
 
 
 def read_source_file(project_path: Path, rel_path: str) -> str:
     """Read a source file. Blocks .smrt/, tests/, docs/ and secret files."""
+    blocked, reason = is_blocked(project_path, rel_path)
+    if blocked:
+        return f"Access denied: {reason}"
     first_part = Path(rel_path).parts[0] if Path(rel_path).parts else ""
     if first_part in _BLOCKED_DIRS:
         raise PermissionError(f"read_source_file cannot read from {first_part}/: {rel_path!r}")
@@ -22,6 +26,9 @@ def read_source_file(project_path: Path, rel_path: str) -> str:
 
 def write_source_file(project_path: Path, rel_path: str, content: str) -> str:
     """Write/overwrite a source file. Blocks .smrt/, tests/, docs/."""
+    blocked, reason = is_blocked(project_path, rel_path)
+    if blocked:
+        return f"Access denied: {reason}"
     first_part = Path(rel_path).parts[0] if Path(rel_path).parts else ""
     if first_part in _BLOCKED_DIRS:
         raise PermissionError(f"write_source_file cannot write to {first_part}/: {rel_path!r}")

--- a/backend/src/smrt_agent/agents/qa/tools.py
+++ b/backend/src/smrt_agent/agents/qa/tools.py
@@ -5,9 +5,14 @@ import sys
 from datetime import date
 from pathlib import Path
 
+from smrt_agent.hooks.secret_guard import is_blocked
+
 
 def write_test_file(project_path: Path, filename: str, content: str) -> str:
     """Write a test file to .smrt/tests/. filename must end with .py and contain no path separators."""
+    blocked, reason = is_blocked(project_path, filename)
+    if blocked:
+        return f"Access denied: {reason}"
     if not filename.endswith(".py"):
         raise ValueError(f"Test filename must end with .py: {filename!r}")
     if "/" in filename or "\\" in filename:

--- a/backend/src/smrt_agent/agents/reviewer/tools.py
+++ b/backend/src/smrt_agent/agents/reviewer/tools.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pathspec
 import requests
 
+from smrt_agent.hooks.secret_guard import is_blocked
+
 _SECRET_SPEC = pathspec.PathSpec.from_lines("gitwildmatch", [
     "*.env", ".env", ".env.*", "*secret*", "*credential*",
     "*.pem", "*.key", "*password*", "*.p12", "*.pfx",
@@ -22,6 +24,10 @@ def _gitignore_spec(project_path: Path) -> pathspec.PathSpec:
 
 def list_files(project_path: Path, subdir: str = "") -> list[str]:
     """Return sorted relative paths of all non-secret, non-gitignored source files."""
+    if subdir:
+        blocked, reason = is_blocked(project_path, subdir)
+        if blocked:
+            return [f"Access denied: {reason}"]
     base = project_path / subdir if subdir else project_path
     spec = _gitignore_spec(project_path)
     result = []
@@ -40,6 +46,9 @@ def list_files(project_path: Path, subdir: str = "") -> list[str]:
 
 def read_file(project_path: Path, rel_path: str) -> str:
     """Read a project file. Blocks path traversal and secret files."""
+    blocked, reason = is_blocked(project_path, rel_path)
+    if blocked:
+        return f"Access denied: {reason}"
     if _SECRET_SPEC.match_file(rel_path):
         raise PermissionError(f"Secret file access denied: {rel_path!r}")
     target = (project_path / rel_path).resolve()
@@ -58,6 +67,9 @@ def fetch_url(url: str) -> str:
 
 def write_file(project_path: Path, rel_path: str, content: str) -> str:
     """Write a file. ONLY permitted inside .smrt/."""
+    blocked, reason = is_blocked(project_path, rel_path)
+    if blocked:
+        return f"Access denied: {reason}"
     if not rel_path.startswith(".smrt/"):
         raise PermissionError(f"write_file may only write inside .smrt/: {rel_path!r}")
     target = (project_path / rel_path).resolve()

--- a/backend/src/smrt_agent/api/projects.py
+++ b/backend/src/smrt_agent/api/projects.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -7,10 +8,20 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from smrt_agent.api.deps import get_db
-from smrt_agent.api.schemas import AgentRunOut, ProjectCreate, ProjectOut
+from smrt_agent.api.schemas import AgentRunOut, ProjectConfig, ProjectConfigPatch, ProjectCreate, ProjectOut
 from smrt_agent.db.models import AgentRun, Project
 from smrt_agent.platform_paths import canonicalize
 from smrt_agent.settings import Settings
+
+CONFIG_DEFAULTS = {
+    "reviewer_model": "claude-opus-4-7",
+    "qa_model": "claude-sonnet-4-6",
+    "coder_model": "claude-sonnet-4-6",
+    "max_fix_attempts": 5,
+    "max_questions_per_attempt": 1,
+    "scheduler_cadence": "daily_0300",
+    "thought_process_mode": False,
+}
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -99,3 +110,42 @@ async def list_runs(
         .order_by(AgentRun.started_at.desc())
     )
     return list(result.scalars().all())
+
+
+@router.get("/{project_id}/config", response_model=ProjectConfig)
+async def get_project_config(
+    project_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ProjectConfig:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    try:
+        stored = json.loads(project.config or '{}')
+    except (json.JSONDecodeError, TypeError):
+        stored = {}
+    merged = {**CONFIG_DEFAULTS, **stored}
+    return ProjectConfig(**merged)
+
+
+@router.patch("/{project_id}/config", response_model=ProjectConfig)
+async def patch_project_config(
+    project_id: int,
+    body: ProjectConfigPatch,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ProjectConfig:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    try:
+        stored = json.loads(project.config or '{}')
+    except (json.JSONDecodeError, TypeError):
+        stored = {}
+    # Merge only the provided (non-None) fields
+    updates = {k: v for k, v in body.model_dump().items() if v is not None}
+    stored.update(updates)
+    project.config = json.dumps(stored)
+    await db.commit()
+    await db.refresh(project)
+    merged = {**CONFIG_DEFAULTS, **json.loads(project.config)}
+    return ProjectConfig(**merged)

--- a/backend/src/smrt_agent/api/schemas.py
+++ b/backend/src/smrt_agent/api/schemas.py
@@ -12,8 +12,29 @@ class ProjectOut(BaseModel):
     name: str
     canonical_path: str
     created_at: datetime
+    config: str = '{}'
 
     model_config = {"from_attributes": True}
+
+
+class ProjectConfig(BaseModel):
+    reviewer_model: str = "claude-opus-4-7"
+    qa_model: str = "claude-sonnet-4-6"
+    coder_model: str = "claude-sonnet-4-6"
+    max_fix_attempts: int = 5
+    max_questions_per_attempt: int = 1
+    scheduler_cadence: str = "daily_0300"
+    thought_process_mode: bool = False
+
+
+class ProjectConfigPatch(BaseModel):
+    reviewer_model: str | None = None
+    qa_model: str | None = None
+    coder_model: str | None = None
+    max_fix_attempts: int | None = None
+    max_questions_per_attempt: int | None = None
+    scheduler_cadence: str | None = None
+    thought_process_mode: bool | None = None
 
 
 class RunCreatedResponse(BaseModel):

--- a/backend/src/smrt_agent/api/stats.py
+++ b/backend/src/smrt_agent/api/stats.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 from typing import Annotated
 
+import yaml
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -102,6 +104,44 @@ async def get_heatmap(
 
     files.sort(key=lambda x: x["loc"], reverse=True)
     return {"files": files[:50]}
+
+
+@router.get("/{project_id}/tests")
+async def get_test_status(
+    project_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    yaml_path = Path(project.canonical_path) / ".smrt" / "knowledge" / "test-status.yaml"
+    if not yaml_path.exists():
+        return {"tests": [], "version": 1}
+
+    try:
+        raw = yaml_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw) or {}
+    except Exception:
+        return {"tests": [], "version": 1}
+
+    version = data.get("version", 1)
+    raw_tests: dict = data.get("tests") or {}
+
+    tests = []
+    for name, info in raw_tests.items():
+        if not isinstance(info, dict):
+            continue
+        last_run_at = info.get("last_run_at")
+        tests.append({
+            "name": name,
+            "status": info.get("status", "green"),
+            "last_run_at": last_run_at.isoformat() if hasattr(last_run_at, "isoformat") else (str(last_run_at) if last_run_at is not None else None),
+            "promoted_to": info.get("promoted_to", None),
+            "last_runs": info.get("last_runs") or [],
+        })
+
+    return {"version": version, "tests": tests}
 
 
 @router.get("/{project_id}/stats/doc-completeness")

--- a/backend/src/smrt_agent/db/models.py
+++ b/backend/src/smrt_agent/db/models.py
@@ -16,6 +16,7 @@ class Project(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    config: Mapped[str] = mapped_column(String(4096), nullable=False, default='{}')
 
     runs: Mapped[list["AgentRun"]] = relationship("AgentRun", back_populates="project")
     qa_sessions: Mapped[list["QASession"]] = relationship("QASession", back_populates="project")

--- a/backend/src/smrt_agent/db/schema.py
+++ b/backend/src/smrt_agent/db/schema.py
@@ -1,3 +1,4 @@
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from smrt_agent.db.base import Base
@@ -7,3 +8,11 @@ from smrt_agent.db import models  # noqa: F401 — registers models on Base.meta
 async def init_schema(engine: AsyncEngine) -> None:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        # Migration: add config column to projects if it doesn't exist yet
+        try:
+            await conn.execute(
+                text("ALTER TABLE projects ADD COLUMN config VARCHAR(4096) NOT NULL DEFAULT '{}'")
+            )
+        except Exception:
+            # Column already exists — safe to ignore
+            pass

--- a/backend/src/smrt_agent/hooks/secret_guard.py
+++ b/backend/src/smrt_agent/hooks/secret_guard.py
@@ -1,0 +1,197 @@
+"""Secret guard hook: prevents agents from reading sensitive files.
+
+check_path(project_path, file_path) -> str | None
+    Returns None if access is allowed, or a denial reason string if blocked.
+
+is_blocked(project_path, file_path) -> tuple[bool, str]
+    Returns (blocked, reason); reason is empty string when not blocked.
+"""
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path, PurePosixPath
+
+try:
+    import pathspec as _pathspec
+
+    _PATHSPEC_AVAILABLE = True
+except ImportError:
+    _pathspec = None  # type: ignore[assignment]
+    _PATHSPEC_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Always-deny patterns (applied to basename AND full relative path)
+# ---------------------------------------------------------------------------
+
+# Exact name matches
+_EXACT_DENY: frozenset[str] = frozenset(
+    {
+        ".env",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "credentials.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "secret.yml",
+        "secret.yaml",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+    }
+)
+
+# Glob patterns matched against the basename
+_GLOB_DENY: tuple[str, ...] = (
+    ".env.*",
+    ".env_*",
+    "*.key",
+    "*.pem",
+    "*.p12",
+    "*.pfx",
+    "*.crt",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "*.ppk",
+    "service-account*.json",
+    "gcloud-key*.json",
+)
+
+# Path prefix segments that are always blocked (applied to the full path)
+_PREFIX_DENY: tuple[str, ...] = (
+    ".aws/",
+    ".azure/",
+    ".gcloud/",
+    ".git/",
+)
+
+# Exact relative sub-paths (anywhere in the tree)
+_SUBPATH_DENY: tuple[str, ...] = (
+    ".kube/config",
+)
+
+# Exception: always allow paths under this prefix even if gitignored
+_GITIGNORE_EXCEPTION_PREFIX = "tests/generated/"
+
+
+def _normalise(file_path: str) -> str:
+    """Return the path with forward slashes, no leading slash."""
+    return file_path.replace("\\", "/").lstrip("/")
+
+
+def _basename(file_path: str) -> str:
+    return PurePosixPath(_normalise(file_path)).name
+
+
+def _check_always_deny(norm_path: str) -> str | None:
+    """Return a denial reason if the path hits any always-deny rule."""
+    name = _basename(norm_path)
+
+    # Exact name check
+    if name in _EXACT_DENY:
+        return f"sensitive file '{name}' is always blocked"
+
+    # Glob pattern check on basename
+    for pat in _GLOB_DENY:
+        if fnmatch.fnmatch(name, pat):
+            return f"filename '{name}' matches sensitive pattern '{pat}'"
+
+    # Also match glob patterns against the full relative path
+    for pat in _GLOB_DENY:
+        if fnmatch.fnmatch(norm_path, pat):
+            return f"path '{norm_path}' matches sensitive pattern '{pat}'"
+
+    # Prefix checks (full path)
+    for prefix in _PREFIX_DENY:
+        if norm_path == prefix.rstrip("/") or norm_path.startswith(prefix):
+            return f"path is inside always-blocked directory '{prefix}'"
+
+    # Sub-path checks
+    for sub in _SUBPATH_DENY:
+        # Check if path equals sub, or any trailing component equals sub
+        if norm_path == sub or norm_path.endswith("/" + sub):
+            return f"path '{norm_path}' matches always-blocked path '{sub}'"
+
+    return None
+
+
+def _load_gitignore_specs(project_path: Path) -> "list[tuple[str, object]]":
+    """Walk project_path and collect (base_dir_prefix, PathSpec) pairs.
+
+    Returns an empty list if pathspec is not available.
+    """
+    if not _PATHSPEC_AVAILABLE:
+        return []
+
+    specs: list[tuple[str, object]] = []
+
+    for gi_file in sorted(project_path.rglob(".gitignore")):
+        try:
+            lines = gi_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        try:
+            rel_dir = gi_file.parent.relative_to(project_path)
+        except ValueError:
+            continue
+        prefix = str(rel_dir).replace("\\", "/")
+        if prefix == ".":
+            prefix = ""
+        spec = _pathspec.PathSpec.from_lines("gitwildmatch", lines)  # type: ignore[union-attr]
+        specs.append((prefix, spec))
+
+    return specs
+
+
+def _check_gitignore(
+    specs: "list[tuple[str, object]]",
+    norm_path: str,
+) -> str | None:
+    """Return a denial reason if norm_path is matched by any loaded gitignore spec."""
+    if not specs:
+        return None
+
+    # Exception: always allow tests/generated/ paths
+    if norm_path.startswith(_GITIGNORE_EXCEPTION_PREFIX):
+        return None
+
+    for base_prefix, spec in specs:
+        if base_prefix:
+            # Only apply specs from subdirectories to paths beneath that directory
+            if not norm_path.startswith(base_prefix + "/"):
+                continue
+            relative_to_spec = norm_path[len(base_prefix) + 1 :]
+        else:
+            relative_to_spec = norm_path
+
+        if spec.match_file(relative_to_spec):  # type: ignore[union-attr]
+            return f"path '{norm_path}' is matched by .gitignore"
+
+    return None
+
+
+def check_path(project_path: Path, file_path: str) -> str | None:
+    """Return denial reason string, or None if access is allowed."""
+    norm = _normalise(file_path)
+
+    # 1. Always-deny list
+    reason = _check_always_deny(norm)
+    if reason:
+        return reason
+
+    # 2. Gitignore check
+    specs = _load_gitignore_specs(project_path)
+    reason = _check_gitignore(specs, norm)
+    if reason:
+        return reason
+
+    return None
+
+
+def is_blocked(project_path: Path, file_path: str) -> tuple[bool, str]:
+    """Return (blocked, reason). reason is empty string when not blocked."""
+    reason = check_path(project_path, file_path)
+    if reason is None:
+        return False, ""
+    return True, reason

--- a/backend/tests/test_reviewer_tools.py
+++ b/backend/tests/test_reviewer_tools.py
@@ -54,8 +54,8 @@ def test_read_file_blocks_path_traversal(tmp_path):
 def test_read_file_blocks_secret_files(tmp_path):
     project = _make_project(tmp_path)
     (tmp_path / ".env").write_text("SECRET=abc")
-    with pytest.raises(PermissionError):
-        read_file(project, ".env")
+    result = read_file(project, ".env")
+    assert result.startswith("Access denied:")
 
 
 def test_fetch_url_returns_text():

--- a/backend/tests/test_secret_guard.py
+++ b/backend/tests/test_secret_guard.py
@@ -1,0 +1,179 @@
+"""Tests for smrt_agent.hooks.secret_guard."""
+import pytest
+from pathlib import Path
+
+from smrt_agent.hooks.secret_guard import check_path, is_blocked
+
+
+# ---------------------------------------------------------------------------
+# Always-deny: blocked paths
+# ---------------------------------------------------------------------------
+
+class TestAlwaysDenyBlocked:
+    def test_dotenv_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".env") is not None
+
+    def test_dotenv_local_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".env.local") is not None
+
+    def test_dotenv_underscore_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".env_production") is not None
+
+    def test_git_config_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".git/config") is not None
+
+    def test_git_subdir_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".git/objects/abc123") is not None
+
+    def test_private_key_blocked(self, tmp_path):
+        assert check_path(tmp_path, "private.key") is not None
+
+    def test_pem_blocked(self, tmp_path):
+        assert check_path(tmp_path, "server.pem") is not None
+
+    def test_p12_blocked(self, tmp_path):
+        assert check_path(tmp_path, "cert.p12") is not None
+
+    def test_pfx_blocked(self, tmp_path):
+        assert check_path(tmp_path, "cert.pfx") is not None
+
+    def test_crt_blocked(self, tmp_path):
+        assert check_path(tmp_path, "server.crt") is not None
+
+    def test_id_rsa_blocked(self, tmp_path):
+        assert check_path(tmp_path, "id_rsa") is not None
+
+    def test_id_ed25519_blocked(self, tmp_path):
+        assert check_path(tmp_path, "id_ed25519") is not None
+
+    def test_id_ecdsa_blocked(self, tmp_path):
+        assert check_path(tmp_path, "id_ecdsa") is not None
+
+    def test_ppk_blocked(self, tmp_path):
+        assert check_path(tmp_path, "mykey.ppk") is not None
+
+    def test_credentials_json_blocked(self, tmp_path):
+        assert check_path(tmp_path, "credentials.json") is not None
+
+    def test_service_account_json_blocked(self, tmp_path):
+        assert check_path(tmp_path, "service-account-prod.json") is not None
+
+    def test_gcloud_key_json_blocked(self, tmp_path):
+        assert check_path(tmp_path, "gcloud-key-main.json") is not None
+
+    def test_secrets_yaml_blocked(self, tmp_path):
+        assert check_path(tmp_path, "secrets.yaml") is not None
+
+    def test_secrets_yml_blocked(self, tmp_path):
+        assert check_path(tmp_path, "secrets.yml") is not None
+
+    def test_secret_yml_blocked(self, tmp_path):
+        assert check_path(tmp_path, "secret.yml") is not None
+
+    def test_secret_yaml_blocked(self, tmp_path):
+        assert check_path(tmp_path, "secret.yaml") is not None
+
+    def test_aws_dir_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".aws/credentials") is not None
+
+    def test_azure_dir_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".azure/something") is not None
+
+    def test_gcloud_dir_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".gcloud/application_default_credentials.json") is not None
+
+    def test_kube_config_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".kube/config") is not None
+
+    def test_netrc_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".netrc") is not None
+
+    def test_npmrc_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".npmrc") is not None
+
+    def test_pypirc_blocked(self, tmp_path):
+        assert check_path(tmp_path, ".pypirc") is not None
+
+
+# ---------------------------------------------------------------------------
+# Always-deny: allowed paths
+# ---------------------------------------------------------------------------
+
+class TestAlwaysDenyAllowed:
+    def test_normal_config_yaml_allowed(self, tmp_path):
+        assert check_path(tmp_path, "config.yaml") is None
+
+    def test_src_main_py_allowed(self, tmp_path):
+        assert check_path(tmp_path, "src/main.py") is None
+
+    def test_readme_md_allowed(self, tmp_path):
+        assert check_path(tmp_path, "README.md") is None
+
+    def test_py_file_not_blocked_by_crt_rule(self, tmp_path):
+        # .py files must NOT be blocked (*.crt should not catch *.py)
+        assert check_path(tmp_path, "main.py") is None
+
+    def test_nested_py_allowed(self, tmp_path):
+        assert check_path(tmp_path, "src/utils/helpers.py") is None
+
+
+# ---------------------------------------------------------------------------
+# is_blocked convenience wrapper
+# ---------------------------------------------------------------------------
+
+class TestIsBlocked:
+    def test_returns_true_and_reason_for_blocked(self, tmp_path):
+        blocked, reason = is_blocked(tmp_path, ".env")
+        assert blocked is True
+        assert reason != ""
+
+    def test_returns_false_and_empty_for_allowed(self, tmp_path):
+        blocked, reason = is_blocked(tmp_path, "src/main.py")
+        assert blocked is False
+        assert reason == ""
+
+
+# ---------------------------------------------------------------------------
+# Gitignore integration
+# ---------------------------------------------------------------------------
+
+class TestGitignoreCheck:
+    def test_gitignored_file_blocked(self, tmp_path):
+        """A file matching .gitignore patterns should be blocked."""
+        (tmp_path / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        result = check_path(tmp_path, "app.log")
+        assert result is not None, "app.log should be blocked because *.log is gitignored"
+
+    def test_non_gitignored_file_allowed(self, tmp_path):
+        """A file NOT matching .gitignore patterns should be allowed."""
+        (tmp_path / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        result = check_path(tmp_path, "app.py")
+        assert result is None, "app.py should not be blocked"
+
+    def test_tests_generated_exception(self, tmp_path):
+        """Paths under tests/generated/ are always allowed even if tests/ is gitignored."""
+        (tmp_path / ".gitignore").write_text("tests/\n*.py\n", encoding="utf-8")
+        # Even though tests/ is gitignored, tests/generated/ is excepted
+        result = check_path(tmp_path, "tests/generated/test_foo.py")
+        assert result is None, "tests/generated/test_foo.py should NOT be blocked"
+
+    def test_no_gitignore_file_allowed(self, tmp_path):
+        """Without a .gitignore, all non-secret files are allowed."""
+        result = check_path(tmp_path, "some/arbitrary/file.txt")
+        assert result is None
+
+    def test_nested_gitignore_respected(self, tmp_path):
+        """A .gitignore in a subdirectory is respected for files under that dir."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / ".gitignore").write_text("*.secret\n", encoding="utf-8")
+        result = check_path(tmp_path, "subdir/data.secret")
+        assert result is not None, "subdir/data.secret should be blocked by subdir/.gitignore"
+
+    def test_nested_gitignore_does_not_affect_parent(self, tmp_path):
+        """A .gitignore in a subdirectory does NOT block files in other directories."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / ".gitignore").write_text("*.secret\n", encoding="utf-8")
+        result = check_path(tmp_path, "otherdir/data.secret")
+        assert result is None, "otherdir/data.secret should NOT be blocked by subdir/.gitignore"

--- a/bin/setup-vault.py
+++ b/bin/setup-vault.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Initialize an Obsidian vault skeleton in a project's wiki/ directory.
+
+Usage:
+    python bin/setup-vault.py <project-path>
+
+Creates:
+    wiki/index.md              Master catalog with wikilinks template
+    wiki/hot.md                Recent-context cache
+    wiki/log.md                Append-only operation log
+    wiki/_moc/api-reference.md Map of content for API endpoints
+    wiki/_moc/modules.md       Map of content for modules
+    wiki/_moc/recent-changes.md Auto-gen from git log placeholder
+    wiki/_moc/security.md      Security-relevant code paths MOC
+    wiki/meta/dashboard.base   Obsidian Bases dashboard JSON
+
+Each markdown file includes minimal YAML frontmatter with type, tags, and updated date.
+Only creates files/directories that don't already exist — never overwrites.
+"""
+
+import sys
+import json
+from datetime import date
+from pathlib import Path
+
+
+FRONTMATTER_TEMPLATE = """\
+---
+type: {type}
+tags: []
+updated: {date}
+---
+"""
+
+INDEX_MD = """# Vault Index
+
+Master catalog of documentation. Use wikilinks to navigate:
+
+- [[hot|Recent Context]] — Today's active notes
+- [[log|Operation Log]] — Append-only event log
+
+## Maps of Content
+
+- [[_moc/api-reference|API Reference MOC]]
+- [[_moc/modules|Modules MOC]]
+- [[_moc/recent-changes|Recent Changes MOC]]
+- [[_moc/security|Security MOC]]
+
+## Quick Links
+
+- [GitHub Issues](#)
+- [Architecture Docs](#)
+- [Deploy Runbooks](#)
+"""
+
+HOT_MD = """# Hot (Recent Context)
+
+Active work, current issues, today's focus.
+
+## Today's Focus
+
+- [ ] Task 1
+- [ ] Task 2
+
+## Current Issues
+
+(Add blocking issues here)
+
+## Notes
+
+(Ephemeral notes for this work cycle)
+"""
+
+LOG_MD = """# Operation Log
+
+Append-only log of significant events, changes, and decisions.
+
+## Format
+
+- `YYYY-MM-DD HH:MM` — Brief description of change or event
+
+## Entries
+
+(Append new entries at the top)
+"""
+
+API_REFERENCE_MOC = """# API Reference Map of Content
+
+Index of API endpoints and their implementations.
+
+## Endpoints by Resource
+
+- Users — `/api/users/*`
+- Posts — `/api/posts/*`
+- Comments — `/api/comments/*`
+
+## Schema Definitions
+
+(Link to relevant Pydantic models and type definitions)
+"""
+
+MODULES_MOC = """# Modules Map of Content
+
+Overview of project modules and their responsibilities.
+
+## Core Modules
+
+- `auth` — Authentication and authorization
+- `models` — Data models and schemas
+- `service` — Business logic layer
+- `api` — FastAPI route handlers
+
+## Dependencies
+
+(Diagram or adjacency list of module relationships)
+"""
+
+RECENT_CHANGES_MOC = """# Recent Changes Map of Content
+
+Auto-generated from git log (placeholder).
+
+To auto-generate:
+```bash
+git log --oneline -20
+```
+
+## Latest Commits
+
+(Auto-generated placeholder — update manually or via git integration)
+"""
+
+SECURITY_MOC = """# Security Map of Content
+
+Security-relevant code paths and vulnerability surface area.
+
+## Authentication & Authorization
+
+(Link to auth-related files)
+
+## Input Validation
+
+(Link to validation schemas and sanitization)
+
+## Database Access
+
+(SQL query construction, injection vectors)
+
+## External APIs & Secrets
+
+(Credential handling, API key management)
+"""
+
+DASHBOARD_BASE = {
+    "version": 1,
+    "filters": [],
+    "columns": []
+}
+
+
+def create_file(path: Path, content: str, frontmatter_type: str) -> bool:
+    """Create file with frontmatter if it doesn't exist. Return True if created."""
+    if path.exists():
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    today = date.today().isoformat()
+    frontmatter = FRONTMATTER_TEMPLATE.format(type=frontmatter_type, date=today)
+
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(frontmatter)
+        f.write(content)
+
+    return True
+
+
+def create_json_file(path: Path, data: dict) -> bool:
+    """Create JSON file if it doesn't exist. Return True if created."""
+    if path.exists():
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+    return True
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python bin/setup-vault.py <project-path>", file=sys.stderr)
+        sys.exit(1)
+
+    project_path = Path(sys.argv[1]).resolve()
+    if not project_path.is_dir():
+        print(f"Error: Project path not found: {project_path}", file=sys.stderr)
+        sys.exit(1)
+
+    wiki_dir = project_path / "wiki"
+    moc_dir = wiki_dir / "_moc"
+    meta_dir = wiki_dir / "meta"
+
+    created = []
+    skipped = []
+
+    # Create markdown files
+    files_to_create = [
+        (wiki_dir / "index.md", INDEX_MD, "index"),
+        (wiki_dir / "hot.md", HOT_MD, "hot"),
+        (wiki_dir / "log.md", LOG_MD, "log"),
+        (moc_dir / "api-reference.md", API_REFERENCE_MOC, "moc"),
+        (moc_dir / "modules.md", MODULES_MOC, "moc"),
+        (moc_dir / "recent-changes.md", RECENT_CHANGES_MOC, "moc"),
+        (moc_dir / "security.md", SECURITY_MOC, "moc"),
+    ]
+
+    for path, content, fm_type in files_to_create:
+        if create_file(path, content, fm_type):
+            created.append(str(path.relative_to(project_path)))
+        else:
+            skipped.append(str(path.relative_to(project_path)))
+
+    # Create dashboard.base
+    if create_json_file(meta_dir / "dashboard.base", DASHBOARD_BASE):
+        created.append(str((meta_dir / "dashboard.base").relative_to(project_path)))
+    else:
+        skipped.append(str((meta_dir / "dashboard.base").relative_to(project_path)))
+
+    # Print summary
+    if created:
+        print(f"Created {len(created)} file(s):")
+        for path in created:
+            print(f"  + {path}")
+
+    if skipped:
+        print(f"Skipped {len(skipped)} file(s) (already exist):")
+        for path in skipped:
+            print(f"  - {path}")
+
+    if not created:
+        print("No files created (vault already exists).")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/agent-design.md
+++ b/docs/agent-design.md
@@ -1,0 +1,135 @@
+# Agent Design
+
+## Reviewer (claude-opus-4-7)
+
+The Reviewer is the root agent and the only agent that reasons over the whole codebase.
+It also acts as Orchestrator and Documenter — these are roles, not separate processes.
+
+**Responsibilities**
+
+- **Init audit**: walks `src/**` AST, reads `README.md` and existing docs, fetches
+  `/openapi.json` from the running sandbox, writes the initial `.smrt/Project.md`, and
+  seeds `docs/` and `wiki/` via `DocBackend`.
+- **Periodic checkup** (scheduler or commit trigger): re-reads recent commits and changed
+  files, produces a structured test plan (`.smrt/test-plan.yaml`), delegates to QA.
+- **Doc maintenance**: after every accepted PR, calls `GitHubBackend` and
+  `ObsidianBackend` to upsert affected endpoint and module docs.
+- **Project.md ownership**: the only agent permitted to write `.smrt/Project.md`. Updates
+  it after human PR acceptance, PR rejection (lessons), or false-positive ticket rejection.
+
+**Tools** (defined in `agents/reviewer/budget.py`)
+
+`list_files`, `read_file`, `fetch_url`, `write_file` — `write_file` is restricted to
+paths starting with `.smrt/`.
+
+**Model**: `claude-opus-4-7` (env `SMRT_MODEL_REVIEWER`). Configurable per project.
+
+**Permission mode**: default. The `can_use_tool` callback in `orchestrator.py` gates writes
+to `Project.md`, `docs/`, and `wiki/` in thought-process mode.
+
+---
+
+## QA Agent (claude-sonnet-4-6)
+
+The QA agent owns tests and enforces the blackbox boundary with the Coder.
+
+**Responsibilities**
+
+- Convert test-plan entries into executable pytest tests written to `.smrt/tests/`.
+- Run pytest inside the Docker sandbox; evaluate results.
+- When a test fails and confidence ≥ 0.6 (configurable), call `write_bug_ticket` to
+  produce a `.smrt/tickets/YYYY-MM-DD-NNN.md` file and emit a `hitl_request` event.
+- During the QA↔Coder loop: re-run the hidden test after each Coder submission; return a
+  structured verdict (`done` / `error`) — behavioral description only, never test code.
+- Append resolved bugs to `.smrt/bugs-resolved.md` via `append_bugs_resolved`.
+- Update `.smrt/test-status.md` to record run history and promotion state.
+
+**Three test strategies** (driven by test-plan `category` field)
+
+| Category | Strategy |
+|---|---|
+| `static` | Conventional assertion-style pytest |
+| `logical` | Hypothesis property tests + specific corner-case assertions; mutation-guided (mutmut/cosmic-ray surviving mutants become new tests) |
+| `security` | Both above + negative-auth and authz variants |
+
+**Test-status promotion logic** — tests with > 10 consecutive passes are promoted to weekly
+sampling; any red test is promoted to every checkup. Tracked in `.smrt/test-status.md`.
+
+**Blackbox enforcement** — QA never exposes test file paths, assertion values, or test code
+to the Coder. This is enforced at the tool level: `write_test_file` writes only to
+`.smrt/tests/`; the Coder's tool list has no `read_source_file` for that directory.
+Behavioral feedback examples:
+
+- Allowed: _"The endpoint still returns 200 with the password hash present in the response."_
+- Blocked: _"Your test expects the response to not contain 'hashed_password'."_
+
+**Tools** (defined in `agents/qa/budget.py`)
+
+`list_files`, `read_file`, `write_test_file`, `run_pytest`, `write_bug_ticket`,
+`write_test_status`, `append_bugs_resolved`.
+
+**Model**: `claude-sonnet-4-6` (env `SMRT_MODEL_QA`).
+
+---
+
+## Coder Agent (claude-sonnet-4-6)
+
+The Coder implements fixes without ever seeing test code.
+
+**Responsibilities**
+
+- Receive a bug ticket with the `reproducing_test` field replaced with
+  `<redacted: QA will run the hidden test>`.
+- Read `src/**` freely; implement a fix.
+- Submit the fix (source edits) back to the orchestrator.
+- On rejection: receive QA's behavioral feedback; optionally use one allowed question
+  per attempt (QA answers descriptively, never with code).
+- Never reads `.smrt/tests/`, never runs pytest directly.
+
+**Branch naming**: `smrt/fix/<ticket-id>-<slug>` (managed via `Bash(git:*)` on the target
+repo).
+
+**Tools** (defined in `agents/coder/budget.py`)
+
+`list_files`, `read_source_file`, `write_source_file`. Explicit deny: anything touching
+`tests/**`, `.smrt/**`, `docs/**`, `wiki/**`.
+
+**Model**: `claude-sonnet-4-6` (env `SMRT_MODEL_CODER`).
+
+**Hard cap**: `max_fix_attempts` (default 5, `SMRT_MAX_FIX_ATTEMPTS`). When exceeded,
+QA composes a failure report; Reviewer converts it to a human-facing report at
+`.smrt/reports/<ticket-id>.md`. The UI surfaces it as a failed ticket with "Read report".
+
+---
+
+## Orchestrator (`agents/orchestrator.py`)
+
+`run_qa_session()` is the coordination function called by `api/qa_sessions.py`.
+
+**Loop sequence**
+
+1. Call `run_qa_agent()` — QA inspects the project and either returns `None` (all passing)
+   or a `ticket_id`.
+2. Emit `hitl_request` event → put session into `hitl_waiting` state.
+3. Await `asyncio.Event` (1-hour timeout) for human approve/skip decision.
+4. On **approve**: read ticket file, run current pytest baseline, call `run_coder_agent()`
+   with redacted ticket content.
+5. Re-run pytest; if passing → `done`. If still failing and attempts remain → repeat from
+   step 1 with prior-fix context injected into QA prompt.
+6. On cap hit → return `"error"`.
+
+**Context isolation** — each subagent runs a fresh `anthropic.Anthropic` streaming loop.
+The only context passed between agents is explicit:
+
+- To QA: `.smrt/Project.md` content + prior fix output.
+- To Coder: ticket markdown (redacted) + current pytest output.
+
+**Structured JSON handoffs** — QA verdict arrives as the `ticket_id` return value plus
+session-status events (`done`/`error`). Coder submission is implicit: the orchestrator
+re-runs pytest to verify, rather than trusting a Coder-reported result.
+
+**Budget guardrails** — each agent loop tracks cumulative `(input_tokens, output_tokens)`,
+calls `compute_cost_usd()`, and emits `budget_exceeded` if the per-agent share is hit.
+The per-agent share is `budget_per_run_usd / (max_fix_attempts * 2 + 1)`. Default:
+$1.50/run, $10/day (env `SMRT_BUDGET_PER_RUN_USD`, `SMRT_BUDGET_PER_DAY_USD`). On
+`budget_exceeded`, the orchestrator halts and the UI surfaces the event.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,138 @@
+# Architecture
+
+SMRT Agent is a Dockerized multi-agent system that connects to a local Python FastAPI
+codebase, runs autonomous quality checks (documentation, test generation, bug squashing),
+and surfaces all activity in a React web UI. The backend embeds three Anthropic-powered
+agents, a scheduler, and a file watcher; the frontend consumes a streaming FastAPI API
+and renders live agent activity, bug tickets, and three analytics dashboards.
+
+## System Diagram
+
+```
+Browser
+  │
+  └─► Vite / React 18 (127.0.0.1:5173)   frontend/src/
+        │  SSE streams + REST calls
+        ▼
+      FastAPI backend (127.0.0.1:8000)    backend/src/smrt_agent/
+        │
+        ├─► Reviewer agent (claude-opus-4-7)
+        │     tools: list_files, read_file, fetch_url, write_file
+        │     writes: .smrt/Project.md, docs/, wiki/
+        │
+        ├─► QA agent (claude-sonnet-4-6)
+        │     tools: list_files, read_file, write_test_file, run_pytest,
+        │            write_bug_ticket, write_test_status, append_bugs_resolved
+        │     writes: .smrt/tests/, .smrt/tickets/, .smrt/test-status.md
+        │
+        ├─► Coder agent (claude-sonnet-4-6)
+        │     tools: list_files, read_source_file, write_source_file
+        │     writes: src/** only
+        │
+        ├─► APScheduler  (scheduler.py)  — nightly 03:00 QA runs
+        ├─► File watcher (watchers.py)   — watchfiles, src/**/*.py
+        ├─► SQLite       (state.db)      — projects, runs, qa_sessions
+        └─► DocBackend   (docs/)         — GitHub + Obsidian writers
+
+        target repo mounted at /workspace (read-write)
+        Docker socket mounted for ephemeral sandbox containers
+```
+
+## Component Breakdown
+
+### Backend — `backend/src/smrt_agent/`
+
+| Module | Responsibility |
+|---|---|
+| `main.py` | FastAPI app factory; registers all routers |
+| `api/projects.py` | Project CRUD, registration, path validation |
+| `api/runs.py` | Reviewer runs — POST to start, SSE stream, event log |
+| `api/qa_sessions.py` | QA/Coder sessions — HITL approve/skip endpoints |
+| `api/tickets.py` | Bug ticket listing per project |
+| `api/stats.py` | `/stats/cost`, `/stats/heatmap`, `/stats/doc-completeness` |
+| `api/provenance.py` | `[smrt-provenance]` entry listing |
+| `api/docs.py` | Documentation preview endpoint |
+| `agents/reviewer/` | Anthropic SDK loop, tools, budget for Reviewer |
+| `agents/qa/` | Anthropic SDK loop, tools, budget for QA |
+| `agents/coder/` | Anthropic SDK loop, tools, budget for Coder |
+| `agents/orchestrator.py` | QA↔Coder coordination loop with HITL gate |
+| `docs/backends.py` | `DocBackend` ABC; `GitHubBackend`, `ObsidianBackend` |
+| `scheduler.py` | APScheduler — `CronTrigger(hour=3)` per project |
+| `watchers.py` | watchfiles integration for commit/file-change triggers |
+| `sandbox/` | Docker ephemeral-container lifecycle |
+| `db/` | SQLAlchemy async models: `Project`, `AgentRun`, `QASession` |
+| `settings.py` | Pydantic `Settings` — models, budgets, ports via env vars |
+| `event_log.py` | `EventLogger` — wraps queue, writes `.smrt/runs/*.jsonl` |
+| `knowledge.py` | `compute_doc_score`, `record_doc_score` helpers |
+
+### Frontend — `frontend/src/`
+
+| Component / Page | Responsibility |
+|---|---|
+| `pages/ProjectsPage.tsx` | Project list, Add Project form |
+| `pages/ProjectDetailPage.tsx` | Tabbed detail: audit, QA session, tickets, dashboards, docs |
+| `components/LiveAgentView.tsx` | SSE-driven live tool-call stream for Reviewer runs |
+| `components/QASessionView.tsx` | SSE-driven view for QA↔Coder sessions; approve/skip buttons |
+| `components/AgentTimeline.tsx` | Ordered event log for past runs |
+| `components/TicketsPanel.tsx` | Bug ticket list from `.smrt/tickets/` |
+| `components/CostChart.tsx` | Stacked bar chart — token cost per run by subagent |
+| `components/HeatmapChart.tsx` | Treemap — file LOC vs bugs-resolved count |
+| `components/DocScoreChart.tsx` | Line chart — documentation completeness over time |
+| `components/ProvenancePanel.tsx` | `[smrt-provenance]` JSON trailer viewer |
+| `components/DocPanel.tsx` | Preview of generated `docs/` and `wiki/` content |
+
+## Data Flow
+
+1. **Project registration** — user POSTs a local path; backend validates it is a git repo with Python files; project row written to SQLite.
+2. **Init audit** — `POST /projects/{id}/runs` starts a Reviewer agent task; agent calls `list_files`, `read_file`, `fetch_url` (OpenAPI), then `write_file` to produce `.smrt/Project.md` and seeds `docs/` + `wiki/` via `DocBackend`.
+3. **Periodic checkup** — APScheduler fires `POST /projects/{id}/qa-sessions` at 03:00 daily; same path as a manual QA session trigger.
+4. **QA↔Coder loop** — `orchestrator.py` drives: QA runs pytest, writes ticket if confidence ≥ 0.6, emits `hitl_request` event; frontend shows Approve/Skip; on approve, Coder receives ticket (test path redacted) and edits `src/**`; orchestrator re-runs pytest; repeats up to `max_fix_attempts`.
+5. **PR surface** — on QA acceptance, Reviewer bundles a PR summary; the pending PR appears in the Tickets panel for human acceptance.
+6. **Doc generation** — after every successful run, `docs/service.py` calls `GitHubBackend` and `ObsidianBackend` to upsert endpoint and module docs; `compute_doc_score` appends to `.smrt/doc_scores.jsonl`.
+
+## Storage Layout
+
+```
+SQLite (SMRT_DB_PATH / state.db)
+  tables: projects, agent_runs, qa_sessions
+
+Target repo at /workspace (or local path)
+  .smrt/
+    Project.md          # Reviewer's living knowledge base
+    tickets/            # YYYY-MM-DD-NNN.md per bug
+    tests/              # QA-generated pytest files
+    runs/               # <run-id>.jsonl event logs
+    qa-sessions/        # <session-id>.jsonl event logs
+    test-status.md      # test promotion/demotion state
+    bugs-resolved.md    # append-only resolution log
+    provenance.jsonl    # [smrt-provenance] entries
+    doc_scores.jsonl    # doc completeness history
+  docs/                 # GitHub-native Markdown (GitHubBackend)
+    api/                # per-endpoint .md files + index.md
+    modules/            # per-module .md files
+    decisions/          # ADR files
+  wiki/                 # Obsidian vault (ObsidianBackend)
+    api/, modules/, decisions/  # mirroring docs/ with YAML frontmatter
+```
+
+## Docker Topology
+
+```
+docker-compose.yml
+  smrt-backend   (uvicorn, port 8000, network: default + smrt-internal)
+    volumes:
+      ./backend/src → /app/src
+      /var/run/docker.sock → sandbox orchestration
+      . → /workspace  (target repo mount)
+      smrt-db volume → /app/.smrt
+
+  smrt-frontend  (vite dev, port 5173)
+    volumes: ./frontend/src → /app/src
+
+  smrt-internal network (no gateway — sandbox containers are isolated here)
+
+Ephemeral sandbox containers  smrt-sandbox-<ticket-id>-<timestamp>
+  built from Dockerfile.smrt in target repo
+  CPU: 2 cores, memory: 2 GB, no internet access
+  mounts: src/ (read-only), .smrt/tests/ (read-write for QA)
+```

--- a/docs/evaluation-rubric-mapping.md
+++ b/docs/evaluation-rubric-mapping.md
@@ -1,0 +1,82 @@
+# Evaluation Rubric Mapping
+
+This document maps each SMRT rubric criterion to its concrete implementation.
+
+---
+
+## 1. AI Orchestration
+
+**Spec requirement**: multi-agent hierarchy, context isolation, structured handoffs, budget guardrails.
+
+**Implementation**
+
+| Aspect | Where |
+|---|---|
+| Three-agent hierarchy (Reviewer → QA → Coder) | `agents/orchestrator.py` `run_qa_session()` |
+| Blackbox between QA and Coder enforced at tool level | Coder tools (`agents/coder/budget.py`) omit any path to `.smrt/tests/`; `read_source_file` rejects paths outside `src/` |
+| Context isolation — subagents start fresh; only explicit artifacts passed | `orchestrator.py` lines 40–47 (QA), 121–128 (Coder): only `Project.md` content + ticket/pytest output injected |
+| Structured JSON handoffs | QA returns `ticket_id` (string); Coder result is inferred by re-running pytest; session-status events carry `{"type": "session_status", "status": "..."}` |
+| Budget guardrails — $1.50/run default, $10/day default | `settings.py` `budget_per_run_usd`, `budget_per_day_usd`; per-agent share enforced in each `loop.py`; `budget_exceeded` event halts and surfaces in `LiveAgentView` / `QASessionView` |
+| Subagents cannot spawn subagents | `Agent` tool absent from QA and Coder tool definitions |
+
+**Where to see it in the UI**: the Live Agent View (`components/LiveAgentView.tsx`) and QA Session View (`components/QASessionView.tsx`) show agent transitions in real time. Budget events appear as error-state status badges.
+
+---
+
+## 2. Attention to Detail (Logical Bugs)
+
+**Spec requirement**: find especially logical bugs that a standard linter would miss; test-status memory.
+
+**Implementation**
+
+| Aspect | Where |
+|---|---|
+| Three-strategy logical-bug engine | QA prompt (`prompts/qa.md`); strategy selected by test-plan `category` field |
+| Strategy A — mutation-guided | QA uses mutmut/cosmic-ray on changed source files; surviving mutants become new test-plan entries with `category: logical` |
+| Strategy B — property-based (Hypothesis) | QA generates Hypothesis strategies from Pydantic schemas via OpenAPI spec; 100 examples per property |
+| Strategy C — differential vs git history | QA runs old green tests against new code; unexpected 500s or status-code changes become ticket candidates |
+| Confidence threshold 0.6 before filing a ticket | `agents/qa/tools.py` `write_bug_ticket`; QA prompt instructs confidence gate |
+| Test-status promotion/demotion memory | `agents/qa/tools.py` `write_test_status`; `.smrt/test-status.md`; green-stable tests promoted to weekly, red tests to every checkup |
+| Eval fixtures with intentional logical bugs | `eval-fixtures/todo-api/` — 5 deliberate bugs including missing `response_model`, forgotten `await`, wrong auth order |
+
+**Where to see it in the UI**: the Tickets panel (`components/TicketsPanel.tsx`) lists filed tickets with severity and confidence score. The Heatmap chart (`components/HeatmapChart.tsx`) shows which source files have the most resolved bugs — a direct output of the logical-bug engine. Data sourced from `GET /projects/{id}/stats/heatmap` (`api/stats.py`).
+
+---
+
+## 3. Communication and Critical Thinking (When to Ask)
+
+**Spec requirement**: explicit HITL surface; uncertainty-gated scaffold; display agent thought process.
+
+**Implementation**
+
+| Aspect | Where |
+|---|---|
+| Two mandatory human decisions (ticket confirm, PR accept) | `orchestrator.py` HITL gate; `api/qa_sessions.py` `/approve` and `/skip` endpoints |
+| HITL blocks on `asyncio.Event` with 1-hour timeout | `orchestrator.py` lines 79–95 |
+| Approve/Skip buttons rendered when `status === "hitl_waiting"` | `components/QASessionView.tsx` |
+| Thought-process mode — live agent text stream + inline mutating-tool gates | SSE events `text_delta`, `qa_text_delta`, `coder_text_delta` emitted by every agent loop; `can_use_tool` callback blocks in thought-process mode |
+| Coder's one question per rejection — uncertainty-gated | `settings.py` `max_questions_per_attempt` (default 1); QA answers descriptively |
+| Rejection reason flows to `Project.md` Lessons section | `orchestrator.py` post-rejection path; Reviewer writes updated `.smrt/Project.md` |
+| Live tool-call observability (four collapsible layers) | `components/LiveAgentView.tsx` renders `tool_use` + `tool_result` events; `components/AgentTimeline.tsx` for past runs |
+
+**Where to see it in the UI**: the QA Session View shows the HITL waiting state with Approve/Skip and the real-time agent text stream. The Config section of Project Detail has the autonomy mode toggle that activates thought-process mode.
+
+---
+
+## 4. Bonus (Visual Reports, Performance, Extra Features)
+
+**Spec requirement**: visual dashboards, Obsidian vault, Explain mode, skill acquisition.
+
+**Implementation**
+
+| Aspect | Where |
+|---|---|
+| Dashboard 1 — audit cost breakdown per run | `components/CostChart.tsx`; data from `GET /projects/{id}/stats/cost` (`api/stats.py`) |
+| Dashboard 2 — bug-hunt heatmap | `components/HeatmapChart.tsx`; data from `GET /projects/{id}/stats/heatmap`; tile area = LOC, color = bugs resolved count |
+| Dashboard 3 — documentation completeness over time | `components/DocScoreChart.tsx`; data from `GET /projects/{id}/stats/doc-completeness`; score = (documented endpoints / total) × 0.5 + (documented modules / total) × 0.5 |
+| Obsidian vault (`wiki/`) with YAML frontmatter | `docs/backends.py` `ObsidianBackend.upsert_*`; writes `type`, `tags`, `updated` frontmatter; parallel to `GitHubBackend` |
+| `DocBackend` abstract interface — GitHub + Obsidian live, Jira/Confluence stub | `docs/backends.py`; `JiraBackend` and `ConfluenceBackend` raise `NotImplementedError` with v2 note |
+| Explain mode / change provenance | `[smrt-provenance]` JSON trailer in commit messages; parsed by `api/provenance.py`; displayed in `components/ProvenancePanel.tsx` |
+| Skill acquisition — Project.md grows from every outcome | `agents/reviewer/` writes `.smrt/Project.md`; injected into every QA and Coder context; Lessons section updated on each rejection |
+| `bugs-resolved.md` for semantic search by future agents | `agents/qa/tools.py` `append_bugs_resolved`; QA reads this before generating new tests to avoid re-filing known patterns |
+| Doc completeness tracked and auto-updated after every run | `knowledge.py` `compute_doc_score` + `record_doc_score`; called in `api/runs.py` `_run_task` after `generate_docs` |

--- a/docs/hitl-contract.md
+++ b/docs/hitl-contract.md
@@ -1,0 +1,119 @@
+# HITL Contract
+
+SMRT Agent requires exactly two human decisions per bug fix. Everything else runs
+autonomously. This document states precisely when approvals fire, what happens on each
+path, and how thought-process mode changes the surface.
+
+---
+
+## Two Mandatory Approvals
+
+### 1. Bug Confirmation
+
+**When**: after QA generates a bug ticket (confidence ≥ 0.6) and before the Coder starts
+work.
+
+**Mechanism**: the orchestrator (`agents/orchestrator.py`) emits a `hitl_request` SSE
+event containing the `session_id` and `ticket_id`, then awaits an `asyncio.Event` with a
+1-hour timeout. The frontend (`components/QASessionView.tsx`) renders Approve and Skip
+buttons while `status === "hitl_waiting"`.
+
+**Endpoints**:
+- `POST /projects/{id}/qa-sessions/{session_id}/approve` — sets decision to `"approve"`, unblocks the loop
+- `POST /projects/{id}/qa-sessions/{session_id}/skip` — sets decision to `"skip"`, terminates session
+
+**What the human sees**: the ticket file contents (title, description, observed vs expected
+behavior, code pointers, QA confidence score). The reproducing test path is listed but the
+test code is not shown.
+
+### 2. PR Acceptance
+
+**When**: after QA certifies a fix (pytest passes after a Coder submission).
+
+**Mechanism**: the orchestrator returns `"done"` status; the Reviewer composes a PR
+summary and commits the fix on `smrt/fix/<ticket-id>-<slug>`. The UI shows the pending PR
+in the Tickets panel with an Accept button.
+
+**What the human sees**: plain-English PR summary, branch name, files changed, and the
+diff. No test code is included in the PR view (blackbox preserved for audit).
+
+---
+
+## What Runs Autonomously
+
+No human approval is needed for:
+
+- QA writing pytest files to `.smrt/tests/`
+- QA running pytest inside the sandbox
+- QA rejecting a Coder submission and sending behavioral feedback
+- Coder reading `src/**` and editing source files
+- Coder asking its one optional question per fix attempt
+- Reviewer updating `.smrt/Project.md` after acceptance or rejection
+- Reviewer regenerating `docs/` and `wiki/` after a merged change
+- The nightly APScheduler trigger starting a new QA session
+
+---
+
+## Thought-Process Mode
+
+**What changes**: when enabled, the frontend receives live streaming of each agent's text
+output (the `text_delta` / `qa_text_delta` / `coder_text_delta` SSE events that are
+already emitted). Additionally, every mutating tool call (`write_file`, `write_test_file`,
+`write_source_file`) triggers an inline approval gate rather than auto-proceeding.
+
+**How to enable**: toggle "Thought-process mode" in the Config section of the Project
+Detail page (stored per project in the backend settings).
+
+**Inline buttons during thought-process mode**:
+- **Continue** — allow the pending mutating tool call to proceed
+- **Skip** — deny the specific tool call; agent receives a denial result and continues
+- **Pause** — suspend the entire session; human can resume later via the Run History panel
+
+**Implementation**: the `can_use_tool` permission callback in the orchestrator checks the
+current autonomy mode. In default mode it auto-approves within permission-rule bounds. In
+thought-process mode it blocks on a WebSocket round-trip to the UI before returning
+`PermissionResultAllow` or `PermissionResultDeny`.
+
+---
+
+## Rejection Flows
+
+### Human rejects a PR (fix acceptance)
+
+1. Human clicks Reject and provides a free-text reason in the UI.
+2. The reason is stored to `.smrt/knowledge/rejections.jsonl` for audit.
+3. The Reviewer agent receives the reason and asks itself what about the repository it
+   misunderstood that led to the rejection.
+4. The Reviewer appends a new entry to the `## Lessons` section of `.smrt/Project.md`
+   (date-stamped, one-line summary + interpretation).
+5. The ticket status returns to "In Progress"; the next QA session will use the updated
+   `Project.md` context.
+
+### Human rejects a bug ticket (false positive)
+
+1. Human clicks "Reject as false positive" on a pending ticket with an optional reason.
+2. The reason is stored to `.smrt/knowledge/mistakes-pending.jsonl`.
+3. The Reviewer interprets the rejection as an invariant update (e.g., _"this field is
+   intentionally present in the response for internal clients"_) and updates
+   `Project.md`'s `## Architecture invariants` or `## Known sharp edges` section.
+4. The ticket is closed; `test-status.md` marks the associated test as suppressed so it
+   is not promoted to future checkups.
+
+---
+
+## Max Fix Attempts Exceeded
+
+**Default cap**: `max_fix_attempts = 5` (env `SMRT_MAX_FIX_ATTEMPTS`, configurable in UI).
+
+When the Coder fails to produce a passing fix within the cap:
+
+1. **QA composes a failure report** containing: bug restated, per-attempt summary (what
+   changed, what still failed), and theories about why the fix kept missing the mark.
+2. **Reviewer reads the QA report** and the Coder's edit history, then writes a
+   human-facing final report to `.smrt/reports/<ticket-id>.md`. The hidden test code is
+   not included in this report.
+3. The ticket status is set to "Failed" in the UI with a "Read report" action.
+4. The human can: escalate to a developer, split the ticket, or close it as out-of-scope.
+5. If the human chooses to escalate, the reason and report path are appended to
+   `Project.md`'s `## Known sharp edges` so future agents do not attempt the same fix
+   strategy.

--- a/eval-fixtures/todo-api/docs/api/GET_health.md
+++ b/eval-fixtures/todo-api/docs/api/GET_health.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** Liveness probe; returns `{"status": "ok"}`.
+**Purpose:** Liveness probe; returns `{"status": "ok"}`

--- a/eval-fixtures/todo-api/docs/api/GET_stats.md
+++ b/eval-fixtures/todo-api/docs/api/GET_stats.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** Returns `{completed_count, total}`.
+**Purpose:** Returns `{completed_count, total}`

--- a/eval-fixtures/todo-api/docs/api/GET_todos.md
+++ b/eval-fixtures/todo-api/docs/api/GET_todos.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** List all todos (raw dicts, no response model).
+**Purpose:** List all todos

--- a/eval-fixtures/todo-api/docs/api/GET_users.md
+++ b/eval-fixtures/todo-api/docs/api/GET_users.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** List all users as `UserOut`.
+**Purpose:** List all users

--- a/eval-fixtures/todo-api/docs/api/PATCH_todos_{todo_id}_complete.md
+++ b/eval-fixtures/todo-api/docs/api/PATCH_todos_{todo_id}_complete.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** Mark a todo done and increment a global completed counter.
+**Purpose:** Mark a todo as done and increment a global `_completed_count`

--- a/eval-fixtures/todo-api/docs/api/POST_todos.md
+++ b/eval-fixtures/todo-api/docs/api/POST_todos.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** Create a todo from `{title, owner_id, due_at?}`. `owner_id` is taken from the request body, not validated against existing users.
+**Purpose:** Create a todo from `{title, owner_id, due_at?}` (status 201)

--- a/eval-fixtures/todo-api/docs/api/POST_users.md
+++ b/eval-fixtures/todo-api/docs/api/POST_users.md
@@ -2,4 +2,4 @@
 
 **Authentication:** None
 
-**Purpose:** Create a user from `{email, password}`; returns `UserOut` (id, email). Stores `password_hash` server-side as the literal string `f"hashed:{password}"`.
+**Purpose:** Create a user from `{email, password}`; returns the stored user record (status 201)

--- a/eval-fixtures/todo-api/docs/modules/todo-api.md
+++ b/eval-fixtures/todo-api/docs/modules/todo-api.md
@@ -1,5 +1,5 @@
 # todo-api
 
-A minimal FastAPI service that manages users and todo items with in-memory storage. It exposes CRUD-style endpoints for todos plus a basic stats endpoint, and appears intended as an evaluation/sandbox target rather than a production service.
+A minimal FastAPI service for managing users and todo items with simple in-memory storage. Serves as a small CRUD-style API exposing user creation, todo CRUD, completion tracking, and aggregate stats.
 
 **File:** `.smrt/Project.md`

--- a/eval-fixtures/todo-api/wiki/api/GET_health.md
+++ b/eval-fixtures/todo-api/wiki/api/GET_health.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # GET /health
 
 **Authentication:** None
 
-**Purpose:** Liveness probe; returns `{"status": "ok"}`.
+**Purpose:** Liveness probe; returns `{"status": "ok"}`

--- a/eval-fixtures/todo-api/wiki/api/GET_stats.md
+++ b/eval-fixtures/todo-api/wiki/api/GET_stats.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # GET /stats
 
 **Authentication:** None
 
-**Purpose:** Returns `{completed_count, total}`.
+**Purpose:** Returns `{completed_count, total}`

--- a/eval-fixtures/todo-api/wiki/api/GET_todos.md
+++ b/eval-fixtures/todo-api/wiki/api/GET_todos.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # GET /todos
 
 **Authentication:** None
 
-**Purpose:** List all todos (raw dicts, no response model).
+**Purpose:** List all todos

--- a/eval-fixtures/todo-api/wiki/api/GET_users.md
+++ b/eval-fixtures/todo-api/wiki/api/GET_users.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # GET /users
 
 **Authentication:** None
 
-**Purpose:** List all users as `UserOut`.
+**Purpose:** List all users

--- a/eval-fixtures/todo-api/wiki/api/PATCH_todos_{todo_id}_complete.md
+++ b/eval-fixtures/todo-api/wiki/api/PATCH_todos_{todo_id}_complete.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # PATCH /todos/{todo_id}/complete
 
 **Authentication:** None
 
-**Purpose:** Mark a todo done and increment a global completed counter.
+**Purpose:** Mark a todo as done and increment a global `_completed_count`

--- a/eval-fixtures/todo-api/wiki/api/POST_todos.md
+++ b/eval-fixtures/todo-api/wiki/api/POST_todos.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # POST /todos
 
 **Authentication:** None
 
-**Purpose:** Create a todo from `{title, owner_id, due_at?}`. `owner_id` is taken from the request body, not validated against existing users.
+**Purpose:** Create a todo from `{title, owner_id, due_at?}` (status 201)

--- a/eval-fixtures/todo-api/wiki/api/POST_users.md
+++ b/eval-fixtures/todo-api/wiki/api/POST_users.md
@@ -1,11 +1,11 @@
 ---
 type: endpoint
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # POST /users
 
 **Authentication:** None
 
-**Purpose:** Create a user from `{email, password}`; returns `UserOut` (id, email). Stores `password_hash` server-side as the literal string `f"hashed:{password}"`.
+**Purpose:** Create a user from `{email, password}`; returns the stored user record (status 201)

--- a/eval-fixtures/todo-api/wiki/modules/todo-api.md
+++ b/eval-fixtures/todo-api/wiki/modules/todo-api.md
@@ -1,11 +1,11 @@
 ---
 type: module
 tags: []
-updated: 2026-04-25
+updated: 2026-04-26
 ---
 
 # todo-api
 
-A minimal FastAPI service that manages users and todo items with in-memory storage. It exposes CRUD-style endpoints for todos plus a basic stats endpoint, and appears intended as an evaluation/sandbox target rather than a production service.
+A minimal FastAPI service for managing users and todo items with simple in-memory storage. Serves as a small CRUD-style API exposing user creation, todo CRUD, completion tracking, and aggregate stats.
 
 **File:** `.smrt/Project.md`

--- a/eval-fixtures/wild/README.md
+++ b/eval-fixtures/wild/README.md
@@ -1,7 +1,59 @@
-# Wild fixtures
+# Wild Fixtures: Real-World FastAPI Soak Testing
 
-This directory is empty by default. Drop git-cloned real-world FastAPI repos here for soak-testing the agent against unfamiliar code.
+This directory is a placeholder for cloning real-world public FastAPI repositories to test SMRT Agent against unfamiliar, production-grade codebases. By soak-testing against diverse projects, we discover edge cases, patterns the agent misses, and opportunities to improve reasoning.
 
-See the parent `eval-fixtures/README.md` for recommended repos.
+**Everything in this directory except this `README.md` is gitignored** — your clones never commit back to smrt-llm-dev.
 
-Everything in this directory except this `README.md` is gitignored — your local clones never get committed back to `smrt-llm-dev`.
+## Recommended Repositories
+
+### 1. **tiangolo/full-stack-fastapi-template**
+- **GitHub**: https://github.com/tiangolo/full-stack-fastapi-template
+- **Description**: Production-ready FastAPI + React + PostgreSQL starter. Includes authentication, permission scopes, async sqlalchemy, background tasks, email templates.
+- **SMRT finds**: Auth/permission logic flaws, async context bugs, SQL injection risks in query construction, missing validation on request body constraints.
+
+### 2. **nsidnev/fastapi-realworld-example-app**
+- **GitHub**: https://github.com/nsidnev/fastapi-realworld-example-app
+- **Description**: Medium.com-like API with articles, comments, tags, followers. Real data relationships and ORM usage.
+- **SMRT finds**: N+1 query problems, race conditions in create-and-reference patterns, missing pagination limits, inconsistent error codes.
+
+### 3. **zhanymkanov/fastapi-best-practices**
+- **GitHub**: https://github.com/zhanymkanov/fastapi-best-practices
+- **Description**: Best practices repo with multiple patterns: dependency injection, middleware, async generators, proper error handling. Compact, high-signal examples.
+- **SMRT finds**: Subtle dependency lifecycle issues, exception handler shadowing, incorrect async context manager usage.
+
+### 4. **jod35/Blog-API-with-FastAPI**
+- **GitHub**: https://github.com/jod35/Blog-API-with-FastAPI
+- **Description**: Comprehensive blog API with JWT auth, comments, roles, pagination, filtering. Single compact repo.
+- **SMRT finds**: Token expiration edge cases, comment permission leaks, inefficient filter/sort chains on large datasets.
+
+### 5. **litestar-org/litestar** (reference ASGI patterns)
+- **GitHub**: https://github.com/litestar-org/litestar
+- **Description**: Modern ASGI framework (formerly Starlite). Extensive middleware, validation, OpenAPI integration. Use `/examples/` for real patterns.
+- **SMRT finds**: Middleware ordering issues, validation schema conflicts, ORM integration mismatch, subtle async state corruption.
+
+### 6. **fastapi/fastapi** (framework tests and examples)
+- **GitHub**: https://github.com/fastapi/fastapi
+- **Description**: FastAPI framework itself. Explore `/docs/` examples and `/tests/` for edge cases and integration patterns.
+- **SMRT finds**: Undocumented feature interactions, OpenAPI spec generation bugs, Pydantic v2 migration pitfalls.
+
+## How to Use
+
+1. Clone a repo into this directory:
+   ```bash
+   git clone https://github.com/tiangolo/full-stack-fastapi-template eval-fixtures/wild/full-stack-fastapi-template
+   ```
+
+2. Register the workspace in the SMRT Agent UI:
+   - Navigate to your agent's workspace manager
+   - Add `/workspace/eval-fixtures/wild/full-stack-fastapi-template`
+
+3. Run analysis:
+   - The agent will now discover and reason about the cloned codebase
+   - Check agent logs for what issues it flags
+
+## Tips
+
+- **Smaller is better for iteration**: Start with repos under 2000 lines of code (like fastapi-best-practices) to see faster feedback.
+- **Mix patterns**: Clone both monolithic (full-stack) and modular (realworld) repos for variety.
+- **Update periodically**: `cd eval-fixtures/wild/<repo> && git pull` to test against latest changes.
+- **Check local issues first**: Before soak-testing, run the repo's own tests (`pytest`, `docker-compose up`) to ensure it's healthy.

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from './client'
+
+export interface ProjectConfig {
+  reviewer_model: string
+  qa_model: string
+  coder_model: string
+  max_fix_attempts: number
+  max_questions_per_attempt: number
+  scheduler_cadence: string
+  thought_process_mode: boolean
+}
+
+export function getConfig(projectId: number): Promise<ProjectConfig> {
+  return apiFetch<ProjectConfig>(`/projects/${projectId}/config`)
+}
+
+export function patchConfig(
+  projectId: number,
+  config: Partial<ProjectConfig>,
+): Promise<ProjectConfig> {
+  return apiFetch<ProjectConfig>(`/projects/${projectId}/config`, {
+    method: 'PATCH',
+    body: JSON.stringify(config),
+  })
+}

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -57,3 +57,22 @@ export async function getDocScoreHistory(
   )
   return data.history
 }
+
+export interface TestStatusEntry {
+  name: string
+  status: 'green_stable' | 'green' | 'red' | 'flaky'
+  last_run_at: string | null
+  promoted_to: 'per_checkup' | 'daily' | 'weekly' | null
+  last_runs: string[]
+}
+
+export async function getTestStatus(
+  projectId: number,
+  signal?: AbortSignal,
+): Promise<TestStatusEntry[]> {
+  const data = await apiFetch<{ tests: TestStatusEntry[]; version: number }>(
+    `/projects/${projectId}/tests`,
+    { signal },
+  )
+  return data.tests
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { getProject, listRuns, type Project, type AgentRunSummary } from '../api/projects'
+import { getConfig, patchConfig, type ProjectConfig } from '../api/config'
 import { createRun } from '../api/runs'
 import { LiveAgentView } from '../components/LiveAgentView'
 import { createQASession } from '../api/qa_sessions'
@@ -53,12 +54,207 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
+// ── Config tab ────────────────────────────────────────────────────────────
+
+const MODEL_OPTIONS = [
+  { value: 'claude-opus-4-7', label: 'claude-opus-4-7' },
+  { value: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6' },
+  { value: 'claude-haiku-4-5-20251001', label: 'claude-haiku-4-5-20251001' },
+]
+
+const CADENCE_OPTIONS = [
+  { value: 'daily_0300', label: 'Daily at 3am' },
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'manual', label: 'Manual only' },
+]
+
+const CONFIG_DEFAULTS: ProjectConfig = {
+  reviewer_model: 'claude-opus-4-7',
+  qa_model: 'claude-sonnet-4-6',
+  coder_model: 'claude-sonnet-4-6',
+  max_fix_attempts: 5,
+  max_questions_per_attempt: 1,
+  scheduler_cadence: 'daily_0300',
+  thought_process_mode: false,
+}
+
+function ConfigTab({ projectId }: { projectId: number }) {
+  const [config, setConfig] = useState<ProjectConfig>(CONFIG_DEFAULTS)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getConfig(projectId)
+      .then(setConfig)
+      .catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load config'))
+  }, [projectId])
+
+  function handleChange(field: keyof ProjectConfig, value: string | number | boolean) {
+    setConfig((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    setSaveError(null)
+    setSaved(false)
+    try {
+      const updated = await patchConfig(projectId, config)
+      setConfig(updated)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save config')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+        {loadError}
+      </div>
+    )
+  }
+
+  const labelCls = 'block text-sm font-medium text-gray-700 mb-1'
+  const inputCls = 'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+  const selectCls = inputCls
+
+  return (
+    <Card>
+      <CardHeader title="Project Configuration" />
+      <div className="p-5 space-y-5">
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          {/* Reviewer Model */}
+          <div>
+            <label className={labelCls}>Reviewer Model</label>
+            <select
+              className={selectCls}
+              value={config.reviewer_model}
+              onChange={(e) => handleChange('reviewer_model', e.target.value)}
+            >
+              {MODEL_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* QA Model */}
+          <div>
+            <label className={labelCls}>QA Model</label>
+            <select
+              className={selectCls}
+              value={config.qa_model}
+              onChange={(e) => handleChange('qa_model', e.target.value)}
+            >
+              {MODEL_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Coder Model */}
+          <div>
+            <label className={labelCls}>Coder Model</label>
+            <select
+              className={selectCls}
+              value={config.coder_model}
+              onChange={(e) => handleChange('coder_model', e.target.value)}
+            >
+              {MODEL_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Scheduler Cadence */}
+          <div>
+            <label className={labelCls}>Scheduler Cadence</label>
+            <select
+              className={selectCls}
+              value={config.scheduler_cadence}
+              onChange={(e) => handleChange('scheduler_cadence', e.target.value)}
+            >
+              {CADENCE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Max Fix Attempts */}
+          <div>
+            <label className={labelCls}>Max Fix Attempts</label>
+            <input
+              type="number"
+              min={1}
+              max={10}
+              className={inputCls}
+              value={config.max_fix_attempts}
+              onChange={(e) => handleChange('max_fix_attempts', Number(e.target.value))}
+            />
+          </div>
+
+          {/* Max Questions per Attempt */}
+          <div>
+            <label className={labelCls}>Max Questions per Attempt</label>
+            <input
+              type="number"
+              min={0}
+              max={5}
+              className={inputCls}
+              value={config.max_questions_per_attempt}
+              onChange={(e) => handleChange('max_questions_per_attempt', Number(e.target.value))}
+            />
+          </div>
+        </div>
+
+        {/* Thought-Process Mode */}
+        <div className="flex items-center gap-3">
+          <input
+            id="thought-process-mode"
+            type="checkbox"
+            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            checked={config.thought_process_mode}
+            onChange={(e) => handleChange('thought_process_mode', e.target.checked)}
+          />
+          <label htmlFor="thought-process-mode" className="text-sm font-medium text-gray-700">
+            Thought-Process Mode
+          </label>
+        </div>
+
+        {saveError && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {saveError}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          {saved && (
+            <span className="text-sm text-emerald-600 font-medium">Saved!</span>
+          )}
+        </div>
+      </div>
+    </Card>
+  )
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────
 
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>()
   const projectId = Number(id)
 
+  const [activeTab, setActiveTab] = useState<'overview' | 'config'>('overview')
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -157,6 +353,27 @@ export function ProjectDetailPage() {
         <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
         <p className="font-mono text-sm text-gray-400">{project.canonical_path}</p>
       </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-gray-200">
+        {(['overview', 'config'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium capitalize transition-colors border-b-2 -mb-px ${
+              activeTab === tab
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'config' && <ConfigTab projectId={projectId} />}
+
+      {activeTab === 'overview' && <>
 
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{error}</div>
@@ -335,6 +552,8 @@ export function ProjectDetailPage() {
           <DocPanel projectId={projectId} />
         </div>
       </Card>
+
+      </>}
     </div>
   )
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -13,6 +13,7 @@ import { CostChart } from '../components/CostChart'
 import { HeatmapChart } from '../components/HeatmapChart'
 import { DocScoreChart } from '../components/DocScoreChart'
 import { ProvenancePanel } from '../components/ProvenancePanel'
+import { getTestStatus, type TestStatusEntry } from '../api/stats'
 
 // ── Shared UI primitives ──────────────────────────────────────────────────
 
@@ -51,6 +52,168 @@ function StatusBadge({ status }: { status: string }) {
       {isRunning && <span className="w-1.5 h-1.5 rounded-full bg-current animate-pulse" />}
       {status}
     </span>
+  )
+}
+
+// ── Tests tab ─────────────────────────────────────────────────────────────
+
+type TestFilter = 'all' | 'passing' | 'failing'
+
+function testStatusBadgeClass(status: TestStatusEntry['status']): string {
+  const map: Record<string, string> = {
+    green_stable: 'bg-emerald-100 text-emerald-700',
+    green: 'bg-green-100 text-green-700',
+    red: 'bg-red-100 text-red-600',
+    flaky: 'bg-yellow-100 text-yellow-700',
+  }
+  return map[status] ?? 'bg-gray-100 text-gray-500'
+}
+
+function RunDot({ result }: { result: string }) {
+  if (result === 'pass') {
+    return <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-500" title="pass" />
+  }
+  if (result === 'fail') {
+    return <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500" title="fail" />
+  }
+  return <span className="inline-block w-2.5 h-2.5 rounded-sm bg-yellow-400" title={result} />
+}
+
+function formatRelativeTime(isoDate: string | null): string {
+  if (!isoDate) return '—'
+  const d = new Date(isoDate)
+  if (isNaN(d.getTime())) return isoDate
+  const diffMs = Date.now() - d.getTime()
+  const diffMin = Math.floor(diffMs / 60_000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDays = Math.floor(diffHr / 24)
+  if (diffDays < 30) return `${diffDays}d ago`
+  return d.toLocaleDateString()
+}
+
+function TestsTab({ projectId }: { projectId: number }) {
+  const [tests, setTests] = useState<TestStatusEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<TestFilter>('all')
+
+  useEffect(() => {
+    const ac = new AbortController()
+    setLoading(true)
+    setError(null)
+    getTestStatus(projectId, ac.signal)
+      .then((data) => {
+        setTests(data)
+        setLoading(false)
+      })
+      .catch((e) => {
+        if ((e as Error).name !== 'AbortError') {
+          setError(e instanceof Error ? e.message : 'Failed to load test status')
+          setLoading(false)
+        }
+      })
+    return () => ac.abort()
+  }, [projectId])
+
+  const filtered = tests.filter((t) => {
+    if (filter === 'passing') return t.status === 'green' || t.status === 'green_stable'
+    if (filter === 'failing') return t.status === 'red' || t.status === 'flaky'
+    return true
+  })
+
+  const filterBtnCls = (f: TestFilter) =>
+    `px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+      filter === f
+        ? 'bg-blue-600 text-white'
+        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+    }`
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-400 py-8">
+        <span className="animate-spin text-lg">⟳</span>
+        <span>Loading test status…</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title="Test History"
+        action={
+          <div className="flex gap-1">
+            <button className={filterBtnCls('all')} onClick={() => setFilter('all')}>All</button>
+            <button className={filterBtnCls('passing')} onClick={() => setFilter('passing')}>Passing</button>
+            <button className={filterBtnCls('failing')} onClick={() => setFilter('failing')}>Failing / Flaky</button>
+          </div>
+        }
+      />
+      {filtered.length === 0 ? (
+        <div className="px-5 py-8 text-sm text-gray-400 text-center">
+          {tests.length === 0
+            ? 'No test history yet. Run a QA session to generate tests.'
+            : 'No tests match the current filter.'}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs text-gray-400 uppercase tracking-wide">
+              <tr>
+                <th className="text-left px-4 py-2.5">Test</th>
+                <th className="text-left px-4 py-2.5">Status</th>
+                <th className="text-left px-4 py-2.5">Last Runs</th>
+                <th className="text-left px-4 py-2.5">Cadence</th>
+                <th className="text-left px-4 py-2.5">Last Run</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {filtered.map((t) => (
+                <tr key={t.name} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-4 py-2.5 max-w-xs">
+                    <span
+                      className="font-mono text-xs text-gray-700 truncate block"
+                      title={t.name}
+                    >
+                      {t.name}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${testStatusBadgeClass(t.status)}`}>
+                      {t.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex gap-0.5 items-center">
+                      {(t.last_runs ?? []).slice(-5).map((r, i) => (
+                        <RunDot key={i} result={r} />
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 text-xs text-gray-500">
+                    {t.promoted_to ?? '—'}
+                  </td>
+                  <td className="px-4 py-2.5 text-xs text-gray-400">
+                    {formatRelativeTime(t.last_run_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
   )
 }
 
@@ -254,7 +417,7 @@ export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>()
   const projectId = Number(id)
 
-  const [activeTab, setActiveTab] = useState<'overview' | 'config'>('overview')
+  const [activeTab, setActiveTab] = useState<'overview' | 'config' | 'tests'>('overview')
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -356,7 +519,7 @@ export function ProjectDetailPage() {
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200">
-        {(['overview', 'config'] as const).map((tab) => (
+        {(['overview', 'tests', 'config'] as const).map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -372,6 +535,7 @@ export function ProjectDetailPage() {
       </div>
 
       {activeTab === 'config' && <ConfigTab projectId={projectId} />}
+      {activeTab === 'tests' && <TestsTab projectId={projectId} />}
 
       {activeTab === 'overview' && <>
 

--- a/frontend/src/test/ProjectDetailPage.test.tsx
+++ b/frontend/src/test/ProjectDetailPage.test.tsx
@@ -79,6 +79,9 @@ const server = setupServer(
   http.post('http://localhost/api/projects/1/qa-sessions', () =>
     HttpResponse.json({ session_id: 'sess-xyz', status: 'pending' }, { status: 202 }),
   ),
+  http.get('http://localhost/api/projects/1/tests', () =>
+    HttpResponse.json({ version: 1, tests: [] }),
+  ),
 )
 
 beforeAll(() => server.listen())
@@ -196,5 +199,83 @@ describe('ProjectDetailPage', () => {
   it('renders the ProvenancePanel dashboard section', async () => {
     renderPage()
     await waitFor(() => expect(screen.getByTestId('provenance-panel')).toBeInTheDocument())
+  })
+
+  it('shows Tests tab in the tab bar', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByRole('button', { name: /^tests$/i })).toBeInTheDocument())
+  })
+
+  it('shows empty state when Tests tab has no test data', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^tests$/i }))
+    await user.click(screen.getByRole('button', { name: /^tests$/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/no test history yet/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('shows test rows when Tests tab has data', async () => {
+    server.use(
+      http.get('http://localhost/api/projects/1/tests', () =>
+        HttpResponse.json({
+          version: 1,
+          tests: [
+            {
+              name: 'tests/generated/test_bug_0042.py::test_password_hash_not_leaked',
+              status: 'green',
+              last_run_at: '2026-04-24T03:00:00Z',
+              promoted_to: 'per_checkup',
+              last_runs: ['pass', 'pass', 'fail', 'pass', 'pass'],
+            },
+          ],
+        }),
+      ),
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^tests$/i }))
+    await user.click(screen.getByRole('button', { name: /^tests$/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/test_password_hash_not_leaked/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByText('per_checkup')).toBeInTheDocument()
+  })
+
+  it('filters Tests tab to passing only', async () => {
+    server.use(
+      http.get('http://localhost/api/projects/1/tests', () =>
+        HttpResponse.json({
+          version: 1,
+          tests: [
+            {
+              name: 'tests/test_passing.py::test_ok',
+              status: 'green_stable',
+              last_run_at: null,
+              promoted_to: 'daily',
+              last_runs: ['pass', 'pass'],
+            },
+            {
+              name: 'tests/test_failing.py::test_bad',
+              status: 'red',
+              last_run_at: null,
+              promoted_to: null,
+              last_runs: ['fail', 'fail'],
+            },
+          ],
+        }),
+      ),
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^tests$/i }))
+    await user.click(screen.getByRole('button', { name: /^tests$/i }))
+    await waitFor(() => screen.getByText(/test_passing/i))
+    expect(screen.getByText(/test_failing/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^passing$/i }))
+    await waitFor(() => expect(screen.queryByText(/test_failing/i)).not.toBeInTheDocument())
+    expect(screen.getByText(/test_passing/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- **README.md rewrite** — evaluator-facing ≤3-minute demo path, replaces stale "Planning phase" status
- **4 new docs files** — architecture.md, agent-design.md, hitl-contract.md, evaluation-rubric-mapping.md
- **Config tab** in ProjectDetailPage — model selector per subagent, max_fix_attempts, scheduler cadence, thought-process toggle; backed by PATCH /projects/{id}/config
- **Tests tab** in ProjectDetailPage — renders test-status.yaml as a filterable table (green_stable/green/red/flaky badges, last-N-runs dots, cadence); backed by GET /projects/{id}/tests
- **Secret guard hook** — gitignore-aware PreToolUse deny rule covering .env, *.key, *.pem, id_rsa, credentials.json, .git/ etc.; wired into Reviewer/QA/Coder tool dispatch
- **eval-fixtures/wild/README.md** — soak-test guide with 6 recommended public FastAPI repos
- **bin/setup-vault.py** — cross-platform Obsidian vault skeleton initializer

## Test plan

- [ ] Frontend: 73 tests passing (`npx vitest run`)
- [ ] Backend: 117 passing, 1 pre-existing skip (`python -m pytest --ignore=tests/test_qa_tools.py`)
- [ ] Secret guard: 41 new tests in `tests/test_secret_guard.py`
- [ ] Config tab: load project → switch to Config tab → change model → Save → reload page → values persist
- [ ] Tests tab: appears when test-status.yaml exists; shows empty state when absent
- [ ] `docker compose up` → register todo-api → follow README demo path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add project-level configuration and test history tabs to the project detail UI, wire them to new backend endpoints, harden agent tooling with a secret-guard hook, and expand documentation and evaluation fixtures.

New Features:
- Introduce Config and Tests tabs on the Project Detail page, backed by new project config and test-status APIs.
- Provide an Obsidian vault setup script for initializing a wiki skeleton in project repos.

Bug Fixes:
- Route agent file-access through a secret-guard hook to block access to sensitive or gitignored files instead of raising unstructured errors.

Enhancements:
- Persist per-project agent and scheduler settings in the database with sane defaults and expose them via a typed config API.
- Surface generated test-status metadata from the backend as a filterable test history table in the UI.
- Extend the projects schema with a JSON config column and add a lightweight migration in schema initialization.
- Refine reviewer/QA/Coder tools to respect the new secret-guard decisions while keeping existing behavioral constraints.

Documentation:
- Rewrite the README with a short evaluator-focused demo path, configuration docs, and troubleshooting guidance.
- Add architecture, agent-design, HITL contract, evaluation-rubric mapping, and wild fixtures soak-test documentation.

Tests:
- Add frontend tests for the new Tests tab behavior and filtering.
- Introduce a dedicated secret-guard test suite and update existing tests to align with guarded access semantics.

Chores:
- Document recommended real-world FastAPI repositories for wild soak testing in eval fixtures.