### PR TITLE
M7+M8: Submission polish — UI tabs, PR surface, Lessons, blackbox self-test

### DIFF
--- a/backend/src/smrt_agent/agents/orchestrator.py
+++ b/backend/src/smrt_agent/agents/orchestrator.py
@@ -1,5 +1,6 @@
 """QA session orchestrator: coordinates QA → HITL → Coder → recheck loop."""
 import asyncio
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -10,6 +11,20 @@ from smrt_agent.agents.qa.tools import run_pytest
 
 def _ts() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _record_pending_pr(project_path: Path, ticket_id: str, session_id: str, recheck_output: str) -> None:
+    """Append a pending PR entry to .smrt/pending-prs.jsonl."""
+    pr_log = project_path / ".smrt" / "pending-prs.jsonl"
+    pr_log.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "ticket_id": ticket_id,
+        "session_id": session_id,
+        "recheck_output": recheck_output[:500],
+        "fixed_at": _ts(),
+    }
+    with pr_log.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
 
 
 async def run_qa_session(
@@ -136,6 +151,8 @@ async def run_qa_session(
         })
 
         if "passed" in recheck_output and "failed" not in recheck_output:
+            _record_pending_pr(project_path, ticket_id, session_id, recheck_output)
+            await queue.put({"type": "pr_ready", "ticket_id": ticket_id, "session_id": session_id, "ts": _ts()})
             await queue.put({
                 "type": "session_status",
                 "status": "done",

--- a/backend/src/smrt_agent/api/pr.py
+++ b/backend/src/smrt_agent/api/pr.py
@@ -4,13 +4,27 @@ from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from smrt_agent.api.deps import get_db
 from smrt_agent.db.models import Project
 from smrt_agent.agents.qa.tools import append_bugs_resolved
+from smrt_agent.knowledge import append_lesson, append_rejection
 
 router = APIRouter(prefix="/projects", tags=["pr"])
+
+
+class RejectBody(BaseModel):
+    reason: str = "No reason given"
+
+
+def _get_ticket_title(project_path: Path, ticket_id: str) -> str:
+    ticket_path = project_path / ".smrt" / "tickets" / f"{ticket_id}.md"
+    if ticket_path.exists():
+        lines = ticket_path.read_text(encoding="utf-8").splitlines()
+        return lines[0].lstrip("#").strip() if lines else ticket_id
+    return ticket_id
 
 
 def _read_pending_prs(project_path: Path) -> list[dict]:
@@ -65,6 +79,8 @@ async def accept_pr(
     _write_pending_prs(project_path, remaining)
 
     append_bugs_resolved(project_path, ticket_id, "Accepted via PR surface review.")
+    ticket_title = _get_ticket_title(project_path, ticket_id)
+    append_lesson(project_path, ticket_id, "accepted", f"{ticket_title} — fix passed all tests.")
     return {"ticket_id": ticket_id, "status": "accepted"}
 
 
@@ -73,6 +89,7 @@ async def reject_pr(
     project_id: int,
     ticket_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    body: RejectBody = RejectBody(),
 ) -> dict:
     project = await db.get(Project, project_id)
     if project is None:
@@ -84,4 +101,8 @@ async def reject_pr(
     if len(remaining) == len(entries):
         raise HTTPException(status_code=404, detail="No pending PR for this ticket")
     _write_pending_prs(project_path, remaining)
+    ticket_title = _get_ticket_title(project_path, ticket_id)
+    reason = body.reason
+    append_lesson(project_path, ticket_id, "rejected", f"{ticket_title} — rejected: {reason}")
+    append_rejection(project_path, ticket_id, ticket_title, reason)
     return {"ticket_id": ticket_id, "status": "rejected"}

--- a/backend/src/smrt_agent/api/pr.py
+++ b/backend/src/smrt_agent/api/pr.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from smrt_agent.api.deps import get_db
 from smrt_agent.db.models import Project
 from smrt_agent.agents.qa.tools import append_bugs_resolved
-from smrt_agent.knowledge import append_lesson, append_rejection
+from smrt_agent.knowledge import append_lesson, append_rejection, sync_wiki_log
 
 router = APIRouter(prefix="/projects", tags=["pr"])
 
@@ -81,6 +81,7 @@ async def accept_pr(
     append_bugs_resolved(project_path, ticket_id, "Accepted via PR surface review.")
     ticket_title = _get_ticket_title(project_path, ticket_id)
     append_lesson(project_path, ticket_id, "accepted", f"{ticket_title} — fix passed all tests.")
+    sync_wiki_log(project_path, ticket_id, ticket_title, "accepted")
     return {"ticket_id": ticket_id, "status": "accepted"}
 
 

--- a/backend/src/smrt_agent/api/pr.py
+++ b/backend/src/smrt_agent/api/pr.py
@@ -1,0 +1,87 @@
+"""PR surface API: list pending PRs, accept or reject a fix."""
+import json
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+from smrt_agent.agents.qa.tools import append_bugs_resolved
+
+router = APIRouter(prefix="/projects", tags=["pr"])
+
+
+def _read_pending_prs(project_path: Path) -> list[dict]:
+    pr_log = project_path / ".smrt" / "pending-prs.jsonl"
+    if not pr_log.exists():
+        return []
+    entries = []
+    for line in pr_log.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return entries
+
+
+def _write_pending_prs(project_path: Path, entries: list[dict]) -> None:
+    pr_log = project_path / ".smrt" / "pending-prs.jsonl"
+    pr_log.parent.mkdir(parents=True, exist_ok=True)
+    with pr_log.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+@router.get("/{project_id}/pr/pending")
+async def list_pending_prs(
+    project_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[dict]:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return _read_pending_prs(Path(project.canonical_path))
+
+
+@router.post("/{project_id}/pr/{ticket_id}/accept", status_code=200)
+async def accept_pr(
+    project_id: int,
+    ticket_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    project_path = Path(project.canonical_path)
+
+    entries = _read_pending_prs(project_path)
+    remaining = [e for e in entries if e.get("ticket_id") != ticket_id]
+    if len(remaining) == len(entries):
+        raise HTTPException(status_code=404, detail="No pending PR for this ticket")
+    _write_pending_prs(project_path, remaining)
+
+    append_bugs_resolved(project_path, ticket_id, "Accepted via PR surface review.")
+    return {"ticket_id": ticket_id, "status": "accepted"}
+
+
+@router.post("/{project_id}/pr/{ticket_id}/reject", status_code=200)
+async def reject_pr(
+    project_id: int,
+    ticket_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    project_path = Path(project.canonical_path)
+
+    entries = _read_pending_prs(project_path)
+    remaining = [e for e in entries if e.get("ticket_id") != ticket_id]
+    if len(remaining) == len(entries):
+        raise HTTPException(status_code=404, detail="No pending PR for this ticket")
+    _write_pending_prs(project_path, remaining)
+    return {"ticket_id": ticket_id, "status": "rejected"}

--- a/backend/src/smrt_agent/api/tickets.py
+++ b/backend/src/smrt_agent/api/tickets.py
@@ -24,14 +24,26 @@ async def list_tickets(
     if not tickets_dir.exists():
         return []
 
+    # Read bugs-resolved.md to determine which tickets are closed
+    resolved_ids: set[str] = set()
+    resolved_path = Path(project.canonical_path) / ".smrt" / "bugs-resolved.md"
+    if resolved_path.exists():
+        resolved_text = resolved_path.read_text(encoding="utf-8")
+        for line in resolved_text.splitlines():
+            if line.startswith("## "):
+                resolved_ids.add(line[3:].strip())
+
     results = []
     for path in sorted(tickets_dir.glob("*.md")):
         content = path.read_text(encoding="utf-8")
         lines = content.splitlines()
         title = lines[0].lstrip("#").strip() if lines else path.stem
+        ticket_id = path.stem
+        status = "closed" if ticket_id in resolved_ids else "pending_confirmation"
         results.append({
-            "id": path.stem,
+            "id": ticket_id,
             "title": title,
             "content": content,
+            "status": status,
         })
     return results

--- a/backend/src/smrt_agent/api/tickets.py
+++ b/backend/src/smrt_agent/api/tickets.py
@@ -1,4 +1,5 @@
 """Bug tickets API: list .smrt/tickets/ files for a project."""
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -33,13 +34,31 @@ async def list_tickets(
             if line.startswith("## "):
                 resolved_ids.add(line[3:].strip())
 
+    # Read pending-prs.jsonl for needs_review tickets
+    pending_review_ids: set[str] = set()
+    pr_log = Path(project.canonical_path) / ".smrt" / "pending-prs.jsonl"
+    if pr_log.exists():
+        for line in pr_log.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    entry = json.loads(line)
+                    pending_review_ids.add(entry.get("ticket_id", ""))
+                except json.JSONDecodeError:
+                    pass
+
     results = []
     for path in sorted(tickets_dir.glob("*.md")):
         content = path.read_text(encoding="utf-8")
         lines = content.splitlines()
         title = lines[0].lstrip("#").strip() if lines else path.stem
         ticket_id = path.stem
-        status = "closed" if ticket_id in resolved_ids else "pending_confirmation"
+        if ticket_id in resolved_ids:
+            status = "closed"
+        elif ticket_id in pending_review_ids:
+            status = "needs_review"
+        else:
+            status = "pending_confirmation"
         results.append({
             "id": ticket_id,
             "title": title,

--- a/backend/src/smrt_agent/knowledge.py
+++ b/backend/src/smrt_agent/knowledge.py
@@ -98,6 +98,18 @@ def append_lesson(project_path: Path, ticket_id: str, action: str, entry_text: s
     project_md_path.write_text(text, encoding="utf-8")
 
 
+def sync_wiki_log(project_path: Path, ticket_id: str, ticket_title: str, action: str) -> None:
+    """Append a log entry to wiki/log.md on PR accept/reject. Silent no-op if wiki/ absent."""
+    from datetime import datetime, timezone
+    wiki_log = project_path / "wiki" / "log.md"
+    if not wiki_log.parent.exists():
+        return
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    entry = f"- `{ts}` **{ticket_id} ({action})**: {ticket_title}\n"
+    with wiki_log.open("a", encoding="utf-8") as f:
+        f.write(entry)
+
+
 def append_rejection(project_path: Path, ticket_id: str, ticket_title: str, reason: str) -> None:
     """Append a rejection record to .smrt/rejections.jsonl."""
     from datetime import datetime, timezone

--- a/backend/src/smrt_agent/knowledge.py
+++ b/backend/src/smrt_agent/knowledge.py
@@ -57,3 +57,57 @@ def record_provenance(project_path: Path, entry: dict) -> None:
     smrt_dir.mkdir(exist_ok=True)
     with open(smrt_dir / "provenance.jsonl", "a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
+
+
+def append_lesson(project_path: Path, ticket_id: str, action: str, entry_text: str) -> None:
+    """Append a lesson entry to ## Lessons section of .smrt/Project.md.
+
+    Creates the file and section if either doesn't exist.
+    """
+    project_md_path = project_path / ".smrt" / "Project.md"
+    project_md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if project_md_path.exists():
+        text = project_md_path.read_text(encoding="utf-8")
+    else:
+        text = f"# Project: {project_path.name}\n"
+
+    lesson_line = f"- **{ticket_id} ({action})**: {entry_text}"
+
+    if "## Lessons" in text:
+        lines = text.splitlines()
+        out: list[str] = []
+        in_lessons = False
+        inserted = False
+        for line in lines:
+            if line.startswith("## Lessons"):
+                in_lessons = True
+                out.append(line)
+                continue
+            if in_lessons and line.startswith("## ") and not inserted:
+                out.append(lesson_line)
+                inserted = True
+                in_lessons = False
+            out.append(line)
+        if not inserted:
+            out.append(lesson_line)
+        text = "\n".join(out) + "\n"
+    else:
+        text = text.rstrip() + f"\n\n## Lessons\n\n{lesson_line}\n"
+
+    project_md_path.write_text(text, encoding="utf-8")
+
+
+def append_rejection(project_path: Path, ticket_id: str, ticket_title: str, reason: str) -> None:
+    """Append a rejection record to .smrt/rejections.jsonl."""
+    from datetime import datetime, timezone
+    smrt_dir = project_path / ".smrt"
+    smrt_dir.mkdir(exist_ok=True)
+    entry = {
+        "ticket_id": ticket_id,
+        "ticket_title": ticket_title,
+        "reason": reason,
+        "rejected_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(smrt_dir / "rejections.jsonl", "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")

--- a/backend/src/smrt_agent/main.py
+++ b/backend/src/smrt_agent/main.py
@@ -14,6 +14,7 @@ from smrt_agent.api.tickets import router as tickets_router
 from smrt_agent.api.docs import router as docs_router
 from smrt_agent.api.stats import router as stats_router
 from smrt_agent.api.provenance import router as provenance_router
+from smrt_agent.api.pr import router as pr_router
 
 
 @asynccontextmanager
@@ -52,6 +53,7 @@ def create_app() -> FastAPI:
     app.include_router(docs_router)
     app.include_router(stats_router)
     app.include_router(provenance_router)
+    app.include_router(pr_router)
 
     return app
 

--- a/backend/tests/test_blackbox_invariant.py
+++ b/backend/tests/test_blackbox_invariant.py
@@ -1,0 +1,41 @@
+"""Verify the Coder agent cannot read or write the tests/ directory (blackbox invariant)."""
+import pytest
+from smrt_agent.agents.coder.tools import read_source_file, write_source_file
+
+
+def test_read_source_file_blocks_tests_directory(tmp_path):
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_foo.py").write_text("def test_foo(): pass", encoding="utf-8")
+    with pytest.raises(PermissionError, match="tests"):
+        read_source_file(tmp_path, "tests/test_foo.py")
+
+
+def test_write_source_file_blocks_tests_directory(tmp_path):
+    (tmp_path / "tests").mkdir()
+    with pytest.raises(PermissionError, match="tests"):
+        write_source_file(tmp_path, "tests/test_foo.py", "def test_injected(): pass")
+
+
+def test_read_source_file_blocks_smrt_directory(tmp_path):
+    (tmp_path / ".smrt").mkdir()
+    (tmp_path / ".smrt" / "secret.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(PermissionError, match=r"\.smrt"):
+        read_source_file(tmp_path, ".smrt/secret.json")
+
+
+def test_write_source_file_blocks_smrt_directory(tmp_path):
+    with pytest.raises(PermissionError, match=r"\.smrt"):
+        write_source_file(tmp_path, ".smrt/injected.json", "{}")
+
+
+def test_read_source_file_allows_normal_source(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("# app entry point", encoding="utf-8")
+    result = read_source_file(tmp_path, "src/main.py")
+    assert "app entry point" in result
+
+
+def test_write_source_file_allows_normal_source(tmp_path):
+    result = write_source_file(tmp_path, "main.py", "# fixed content")
+    assert "Wrote" in result
+    assert (tmp_path / "main.py").read_text() == "# fixed content"

--- a/backend/tests/test_pr_api.py
+++ b/backend/tests/test_pr_api.py
@@ -1,0 +1,107 @@
+"""Tests for the PR surface API."""
+import json
+import pytest
+from pathlib import Path
+from httpx import AsyncClient, ASGITransport
+
+from smrt_agent.main import app
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+
+
+def _make_override(path: Path):
+    async def override_db():
+        from unittest.mock import AsyncMock, MagicMock
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+    return override_db
+
+
+async def test_list_pending_prs_empty(tmp_path):
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/pr/pending")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_list_pending_prs_returns_entries(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    pr_log = smrt / "pending-prs.jsonl"
+    pr_log.write_text(
+        json.dumps({"ticket_id": "2026-04-24-001", "session_id": "sess-1", "recheck_output": "1 passed", "fixed_at": "2026-04-24T10:00:00Z"}) + "\n",
+        encoding="utf-8"
+    )
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/pr/pending")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["ticket_id"] == "2026-04-24-001"
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_accept_pr_appends_bugs_resolved(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    pr_log = smrt / "pending-prs.jsonl"
+    pr_log.write_text(
+        json.dumps({"ticket_id": "2026-04-24-001", "session_id": "sess-1", "recheck_output": "1 passed", "fixed_at": "2026-04-24T10:00:00Z"}) + "\n",
+        encoding="utf-8"
+    )
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/projects/1/pr/2026-04-24-001/accept")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+        # PR entry removed
+        remaining = [l for l in pr_log.read_text().splitlines() if l.strip()]
+        assert remaining == []
+        # bugs-resolved.md updated
+        resolved = (smrt / "bugs-resolved.md").read_text(encoding="utf-8")
+        assert "2026-04-24-001" in resolved
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_reject_pr_removes_entry(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    pr_log = smrt / "pending-prs.jsonl"
+    pr_log.write_text(
+        json.dumps({"ticket_id": "2026-04-24-001", "session_id": "sess-1", "recheck_output": "1 passed", "fixed_at": "2026-04-24T10:00:00Z"}) + "\n",
+        encoding="utf-8"
+    )
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/projects/1/pr/2026-04-24-001/reject")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "rejected"
+        # PR entry removed, bugs-resolved NOT updated
+        remaining = [l for l in pr_log.read_text().splitlines() if l.strip()]
+        assert remaining == []
+        assert not (smrt / "bugs-resolved.md").exists()
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_accept_pr_404_for_unknown_ticket(tmp_path):
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/projects/1/pr/nonexistent/accept")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_project_md_lessons.py
+++ b/backend/tests/test_project_md_lessons.py
@@ -1,0 +1,150 @@
+"""Tests for Project.md lessons update on PR accept/reject."""
+import json
+import pytest
+from pathlib import Path
+from httpx import AsyncClient, ASGITransport
+
+from smrt_agent.main import app
+from smrt_agent.api.deps import get_db
+from smrt_agent.db.models import Project
+from smrt_agent.knowledge import append_lesson
+
+
+def _make_override(path: Path):
+    async def override_db():
+        from unittest.mock import AsyncMock, MagicMock
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+    return override_db
+
+
+def _make_pending_pr(path: Path, ticket_id: str = "2026-04-24-001") -> None:
+    smrt = path / ".smrt"
+    smrt.mkdir(exist_ok=True)
+    pr_log = smrt / "pending-prs.jsonl"
+    with pr_log.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "ticket_id": ticket_id,
+            "session_id": "sess-1",
+            "recheck_output": "1 passed",
+            "fixed_at": "2026-04-24T10:00:00Z",
+        }) + "\n")
+
+
+def test_append_lesson_creates_lessons_section_in_existing_file(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    project_md = smrt / "Project.md"
+    project_md.write_text("# Project: test\n\n## Purpose\nA test project.\n", encoding="utf-8")
+    append_lesson(tmp_path, "2026-04-24-001", "accepted", "Fixed null pointer.")
+    text = project_md.read_text(encoding="utf-8")
+    assert "## Lessons" in text
+    assert "2026-04-24-001 (accepted)" in text
+    assert "Fixed null pointer." in text
+
+
+def test_append_lesson_appends_to_existing_lessons_section(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    project_md = smrt / "Project.md"
+    project_md.write_text(
+        "# Project: test\n\n## Lessons\n\n- **OLD-001 (accepted)**: Prior fix.\n",
+        encoding="utf-8"
+    )
+    append_lesson(tmp_path, "2026-04-24-002", "rejected", "Bad fix.")
+    text = project_md.read_text(encoding="utf-8")
+    assert "OLD-001" in text
+    assert "2026-04-24-002 (rejected)" in text
+    assert "Bad fix." in text
+
+
+def test_append_lesson_creates_file_and_section_when_neither_exist(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    # No Project.md exists yet
+    append_lesson(tmp_path, "2026-04-24-001", "accepted", "First fix ever.")
+    project_md = smrt / "Project.md"
+    assert project_md.exists()
+    text = project_md.read_text(encoding="utf-8")
+    assert "## Lessons" in text
+    assert "2026-04-24-001 (accepted)" in text
+
+
+def test_append_lesson_inserts_before_next_section(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    project_md = smrt / "Project.md"
+    project_md.write_text(
+        "# Project: test\n\n## Lessons\n\n## Next Section\nContent.\n",
+        encoding="utf-8"
+    )
+    append_lesson(tmp_path, "2026-04-24-001", "accepted", "Inserted fix.")
+    text = project_md.read_text(encoding="utf-8")
+    lesson_pos = text.index("2026-04-24-001")
+    next_section_pos = text.index("## Next Section")
+    assert lesson_pos < next_section_pos
+
+
+async def test_accept_pr_updates_project_md(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    (smrt / "tickets").mkdir()
+    (smrt / "tickets" / "2026-04-24-001.md").write_text(
+        "# Fixed null pointer\n\nDetails here.", encoding="utf-8"
+    )
+    _make_pending_pr(tmp_path)
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/projects/1/pr/2026-04-24-001/accept")
+        assert resp.status_code == 200
+        project_md = (smrt / "Project.md").read_text(encoding="utf-8")
+        assert "## Lessons" in project_md
+        assert "2026-04-24-001 (accepted)" in project_md
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_reject_pr_updates_project_md_and_rejections_log(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    (smrt / "tickets").mkdir()
+    (smrt / "tickets" / "2026-04-24-001.md").write_text(
+        "# Missing input validation\n\nDetails here.", encoding="utf-8"
+    )
+    _make_pending_pr(tmp_path)
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/projects/1/pr/2026-04-24-001/reject",
+                json={"reason": "Regression introduced in auth module"},
+            )
+        assert resp.status_code == 200
+        project_md = (smrt / "Project.md").read_text(encoding="utf-8")
+        assert "## Lessons" in project_md
+        assert "2026-04-24-001 (rejected)" in project_md
+        # Check rejections.jsonl
+        rejections = json.loads((smrt / "rejections.jsonl").read_text(encoding="utf-8").strip())
+        assert rejections["ticket_id"] == "2026-04-24-001"
+        assert "Regression introduced" in rejections["reason"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_reject_pr_uses_default_reason_when_no_body(tmp_path):
+    smrt = tmp_path / ".smrt"
+    smrt.mkdir()
+    _make_pending_pr(tmp_path)
+    app.dependency_overrides[get_db] = _make_override(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/projects/1/pr/2026-04-24-001/reject")
+        assert resp.status_code == 200
+        rejections = json.loads((smrt / "rejections.jsonl").read_text(encoding="utf-8").strip())
+        assert rejections["reason"] == "No reason given"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_tickets_api.py
+++ b/backend/tests/test_tickets_api.py
@@ -71,6 +71,32 @@ async def test_list_tickets_returns_files(tickets_dir):
         app.dependency_overrides.clear()
 
 
+async def test_list_tickets_includes_status_closed_for_resolved(tmp_path):
+    """Tickets mentioned in bugs-resolved.md get status 'closed'."""
+    smrt = tmp_path / ".smrt"
+    (smrt / "tickets").mkdir(parents=True)
+    (smrt / "tickets" / "2026-04-24-001.md").write_text("# Bug\nDetails.", encoding="utf-8")
+    (smrt / "bugs-resolved.md").write_text("## 2026-04-24-001\n\nFixed it.", encoding="utf-8")
+
+    async def override_db():
+        from unittest.mock import AsyncMock, MagicMock
+        db = AsyncMock()
+        project = MagicMock(spec=Project)
+        project.canonical_path = str(tmp_path)
+        db.get = AsyncMock(return_value=project)
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/projects/1/tickets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["status"] == "closed"
+    finally:
+        app.dependency_overrides.clear()
+
+
 async def test_list_tickets_404_for_unknown_project():
     async def override_db():
         from unittest.mock import AsyncMock

--- a/frontend/src/api/pr.ts
+++ b/frontend/src/api/pr.ts
@@ -1,0 +1,20 @@
+import { apiFetch } from './client'
+
+export interface PendingPR {
+  ticket_id: string
+  session_id: string
+  recheck_output: string
+  fixed_at: string
+}
+
+export async function getPendingPRs(projectId: number): Promise<PendingPR[]> {
+  return apiFetch<PendingPR[]>(`/projects/${projectId}/pr/pending`)
+}
+
+export async function acceptPR(projectId: number, ticketId: string): Promise<{ ticket_id: string; status: string }> {
+  return apiFetch(`/projects/${projectId}/pr/${ticketId}/accept`, { method: 'POST' })
+}
+
+export async function rejectPR(projectId: number, ticketId: string): Promise<{ ticket_id: string; status: string }> {
+  return apiFetch(`/projects/${projectId}/pr/${ticketId}/reject`, { method: 'POST' })
+}

--- a/frontend/src/api/tickets.ts
+++ b/frontend/src/api/tickets.ts
@@ -1,9 +1,12 @@
 import { apiFetch } from './client'
 
+export type TicketStatus = 'pending_confirmation' | 'in_progress' | 'needs_review' | 'closed'
+
 export interface Ticket {
   id: string
   title: string
   content: string
+  status: TicketStatus
 }
 
 export async function listTickets(projectId: number, signal?: AbortSignal): Promise<Ticket[]> {

--- a/frontend/src/components/TicketsPanel.tsx
+++ b/frontend/src/components/TicketsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { listTickets, type Ticket, type TicketStatus } from '../api/tickets'
+import { acceptPR, rejectPR } from '../api/pr'
 
 type ColumnConfig = {
   status: TicketStatus
@@ -45,7 +46,17 @@ const COLUMNS: ColumnConfig[] = [
   },
 ]
 
-function TicketCard({ ticket, col }: { ticket: Ticket; col: ColumnConfig }) {
+function TicketCard({
+  ticket,
+  col,
+  onAccept,
+  onReject,
+}: {
+  ticket: Ticket
+  col: ColumnConfig
+  onAccept?: () => void
+  onReject?: () => void
+}) {
   const [expanded, setExpanded] = useState(false)
   return (
     <div className={`border rounded overflow-hidden ${col.borderCls}`}>
@@ -58,15 +69,47 @@ function TicketCard({ ticket, col }: { ticket: Ticket; col: ColumnConfig }) {
         <span className="ml-auto text-gray-400 shrink-0">{expanded ? '▼' : '▶'}</span>
       </button>
       {expanded && (
-        <pre className="p-3 text-xs whitespace-pre-wrap text-gray-700 bg-white font-sans leading-relaxed">
-          {ticket.content}
-        </pre>
+        <div className="p-3 bg-white">
+          <pre className="text-xs whitespace-pre-wrap text-gray-700 font-sans leading-relaxed">
+            {ticket.content}
+          </pre>
+          {ticket.status === 'needs_review' && (onAccept || onReject) && (
+            <div className="flex gap-2 mt-2">
+              {onAccept && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onAccept() }}
+                  className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium rounded-lg transition-colors"
+                >
+                  Accept
+                </button>
+              )}
+              {onReject && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onReject() }}
+                  className="px-3 py-1.5 bg-red-500 hover:bg-red-600 text-white text-xs font-medium rounded-lg transition-colors"
+                >
+                  Reject
+                </button>
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   )
 }
 
-function KanbanColumn({ col, tickets }: { col: ColumnConfig; tickets: Ticket[] }) {
+function KanbanColumn({
+  col,
+  tickets,
+  projectId,
+  onReviewed,
+}: {
+  col: ColumnConfig
+  tickets: Ticket[]
+  projectId?: number
+  onReviewed?: () => void
+}) {
   return (
     <div className={`flex flex-col rounded-xl border ${col.borderCls} overflow-hidden`}>
       <div className={`px-3 py-2 ${col.headerCls} border-b ${col.borderCls}`}>
@@ -79,7 +122,21 @@ function KanbanColumn({ col, tickets }: { col: ColumnConfig; tickets: Ticket[] }
         {tickets.length === 0 ? (
           <p className="text-xs text-gray-400 italic px-1 pt-1">None</p>
         ) : (
-          tickets.map((t) => <TicketCard key={t.id} ticket={t} col={col} />)
+          tickets.map((t) => (
+            <TicketCard
+              key={t.id}
+              ticket={t}
+              col={col}
+              onAccept={col.status === 'needs_review' && projectId ? async () => {
+                await acceptPR(projectId, t.id)
+                onReviewed?.()
+              } : undefined}
+              onReject={col.status === 'needs_review' && projectId ? async () => {
+                await rejectPR(projectId, t.id)
+                onReviewed?.()
+              } : undefined}
+            />
+          ))
         )}
       </div>
     </div>
@@ -89,9 +146,11 @@ function KanbanColumn({ col, tickets }: { col: ColumnConfig; tickets: Ticket[] }
 export function TicketsPanel({
   projectId,
   refreshKey,
+  onReviewed,
 }: {
   projectId: number
   refreshKey?: number
+  onReviewed?: () => void
 }) {
   const [tickets, setTickets] = useState<Ticket[]>([])
   const [loading, setLoading] = useState(true)
@@ -117,6 +176,12 @@ export function TicketsPanel({
           key={col.status}
           col={col}
           tickets={tickets.filter((t) => t.status === col.status)}
+          projectId={col.status === 'needs_review' ? projectId : undefined}
+          onReviewed={() => {
+            setLoading(true)
+            listTickets(projectId).then((data) => setTickets(data)).finally(() => setLoading(false))
+            onReviewed?.()
+          }}
         />
       ))}
     </div>

--- a/frontend/src/components/TicketsPanel.tsx
+++ b/frontend/src/components/TicketsPanel.tsx
@@ -1,17 +1,60 @@
 import { useEffect, useState } from 'react'
-import { listTickets, type Ticket } from '../api/tickets'
+import { listTickets, type Ticket, type TicketStatus } from '../api/tickets'
 
-function TicketCard({ ticket }: { ticket: Ticket }) {
+type ColumnConfig = {
+  status: TicketStatus
+  label: string
+  headerCls: string
+  borderCls: string
+  bgCls: string
+  textCls: string
+}
+
+const COLUMNS: ColumnConfig[] = [
+  {
+    status: 'pending_confirmation',
+    label: 'Pending Confirmation',
+    headerCls: 'bg-orange-50',
+    borderCls: 'border-orange-200',
+    bgCls: 'bg-orange-50 hover:bg-orange-100',
+    textCls: 'text-orange-800',
+  },
+  {
+    status: 'in_progress',
+    label: 'In Progress',
+    headerCls: 'bg-blue-50',
+    borderCls: 'border-blue-200',
+    bgCls: 'bg-blue-50 hover:bg-blue-100',
+    textCls: 'text-blue-800',
+  },
+  {
+    status: 'needs_review',
+    label: 'Needs Human Review',
+    headerCls: 'bg-yellow-50',
+    borderCls: 'border-yellow-200',
+    bgCls: 'bg-yellow-50 hover:bg-yellow-100',
+    textCls: 'text-yellow-800',
+  },
+  {
+    status: 'closed',
+    label: 'Closed',
+    headerCls: 'bg-emerald-50',
+    borderCls: 'border-emerald-200',
+    bgCls: 'bg-emerald-50 hover:bg-emerald-100',
+    textCls: 'text-emerald-800',
+  },
+]
+
+function TicketCard({ ticket, col }: { ticket: Ticket; col: ColumnConfig }) {
   const [expanded, setExpanded] = useState(false)
-
   return (
-    <div className="border rounded overflow-hidden border-orange-200">
+    <div className={`border rounded overflow-hidden ${col.borderCls}`}>
       <button
-        className="w-full text-left px-3 py-2 flex items-center gap-2 bg-orange-50 hover:bg-orange-100"
+        className={`w-full text-left px-3 py-2 flex items-center gap-2 ${col.bgCls}`}
         onClick={() => setExpanded((p) => !p)}
       >
-        <span className="font-mono text-xs font-medium text-orange-800">{ticket.id}</span>
-        <span className="text-sm text-orange-700 truncate ml-1">{ticket.title}</span>
+        <span className={`font-mono text-xs font-medium ${col.textCls}`}>{ticket.id}</span>
+        <span className={`text-sm truncate ml-1 ${col.textCls}`}>{ticket.title}</span>
         <span className="ml-auto text-gray-400 shrink-0">{expanded ? '▼' : '▶'}</span>
       </button>
       {expanded && (
@@ -19,6 +62,26 @@ function TicketCard({ ticket }: { ticket: Ticket }) {
           {ticket.content}
         </pre>
       )}
+    </div>
+  )
+}
+
+function KanbanColumn({ col, tickets }: { col: ColumnConfig; tickets: Ticket[] }) {
+  return (
+    <div className={`flex flex-col rounded-xl border ${col.borderCls} overflow-hidden`}>
+      <div className={`px-3 py-2 ${col.headerCls} border-b ${col.borderCls}`}>
+        <span className={`text-xs font-semibold uppercase tracking-wide ${col.textCls}`}>
+          {col.label}
+        </span>
+        <span className="ml-2 text-xs text-gray-400">{tickets.length}</span>
+      </div>
+      <div className="flex flex-col gap-2 p-2 flex-1 bg-gray-50 min-h-[4rem]">
+        {tickets.length === 0 ? (
+          <p className="text-xs text-gray-400 italic px-1 pt-1">None</p>
+        ) : (
+          tickets.map((t) => <TicketCard key={t.id} ticket={t} col={col} />)
+        )}
+      </div>
     </div>
   )
 }
@@ -48,9 +111,13 @@ export function TicketsPanel({
     return <p className="text-xs text-gray-400 italic">No bug tickets filed.</p>
 
   return (
-    <div className="space-y-2">
-      {tickets.map((t) => (
-        <TicketCard key={t.id} ticket={t} />
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+      {COLUMNS.map((col) => (
+        <KanbanColumn
+          key={col.status}
+          col={col}
+          tickets={tickets.filter((t) => t.status === col.status)}
+        />
       ))}
     </div>
   )

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -217,6 +217,117 @@ function TestsTab({ projectId }: { projectId: number }) {
   )
 }
 
+// ── Runs tab ──────────────────────────────────────────────────────────────
+
+function RunsTab({
+  projectId,
+  pastRuns,
+}: {
+  projectId: number
+  pastRuns: AgentRunSummary[]
+}) {
+  if (pastRuns.length === 0) {
+    return (
+      <Card>
+        <CardHeader title="Run History" />
+        <div className="px-5 py-8 text-sm text-gray-400 text-center">
+          No runs yet. Click &lsquo;Run Init Audit&rsquo; in the Overview tab.
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader title="Run History" />
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-xs text-gray-400 uppercase tracking-wide">
+            <tr>
+              <th className="text-left px-4 py-2.5">Run ID</th>
+              <th className="text-left px-4 py-2.5">Status</th>
+              <th className="text-right px-4 py-2.5">In tokens</th>
+              <th className="text-right px-4 py-2.5">Out tokens</th>
+              <th className="text-left px-4 py-2.5">Started</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {pastRuns.map((run) => (
+              <React.Fragment key={run.run_id}>
+                <tr className="hover:bg-gray-50 transition-colors">
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-500 truncate max-w-[12rem]">
+                    {run.run_id}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <StatusBadge status={run.status} />
+                  </td>
+                  <td className="px-4 py-2.5 text-right text-gray-500 tabular-nums">
+                    {run.total_input_tokens.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2.5 text-right text-gray-500 tabular-nums">
+                    {run.total_output_tokens.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-400 text-xs">
+                    {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td colSpan={5} className="px-4 py-2">
+                    <PastRunViewer projectId={projectId} runId={run.run_id} />
+                  </td>
+                </tr>
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  )
+}
+
+// ── Docs tab ──────────────────────────────────────────────────────────────
+
+function DocsTab({ projectId }: { projectId: number }) {
+  const [regenMsg, setRegenMsg] = useState<string | null>(null)
+
+  async function handleRegenAll() {
+    const confirmed = window.confirm(
+      'This will re-run the documentation agent for all endpoints and modules. Continue?'
+    )
+    if (!confirmed) return
+    try {
+      await createRun(projectId)
+      setRegenMsg('Regeneration started — switch to the Overview tab to monitor progress.')
+    } catch (e: unknown) {
+      setRegenMsg(e instanceof Error ? e.message : 'Failed to start regeneration')
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title="Documentation"
+        action={
+          <button
+            onClick={handleRegenAll}
+            className="inline-flex items-center gap-2 bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+          >
+            Regenerate All
+          </button>
+        }
+      />
+      {regenMsg && (
+        <div className="mx-5 mt-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+          {regenMsg}
+        </div>
+      )}
+      <div className="p-5">
+        <DocPanel projectId={projectId} />
+      </div>
+    </Card>
+  )
+}
+
 // ── Config tab ────────────────────────────────────────────────────────────
 
 const MODEL_OPTIONS = [
@@ -417,7 +528,7 @@ export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>()
   const projectId = Number(id)
 
-  const [activeTab, setActiveTab] = useState<'overview' | 'config' | 'tests'>('overview')
+  const [activeTab, setActiveTab] = useState<'overview' | 'runs' | 'docs' | 'tests' | 'config'>('overview')
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -519,23 +630,33 @@ export function ProjectDetailPage() {
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200">
-        {(['overview', 'tests', 'config'] as const).map((tab) => (
+        {(
+          [
+            ['overview', 'Overview'],
+            ['runs', 'Runs'],
+            ['docs', 'Docs'],
+            ['tests', 'Tests'],
+            ['config', 'Config'],
+          ] as const
+        ).map(([tab, label]) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
-            className={`px-4 py-2 text-sm font-medium capitalize transition-colors border-b-2 -mb-px ${
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
               activeTab === tab
                 ? 'border-blue-600 text-blue-600'
                 : 'border-transparent text-gray-500 hover:text-gray-700'
             }`}
           >
-            {tab}
+            {label}
           </button>
         ))}
       </div>
 
       {activeTab === 'config' && <ConfigTab projectId={projectId} />}
       {activeTab === 'tests' && <TestsTab projectId={projectId} />}
+      {activeTab === 'runs' && <RunsTab projectId={projectId} pastRuns={pastRuns} />}
+      {activeTab === 'docs' && <DocsTab projectId={projectId} />}
 
       {activeTab === 'overview' && <>
 
@@ -578,54 +699,6 @@ export function ProjectDetailPage() {
           </div>
         )}
       </Card>
-
-      {/* ── Run history ── */}
-      {pastRuns.length > 0 && (
-        <Card>
-          <CardHeader title="Run History" />
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 text-xs text-gray-400 uppercase tracking-wide">
-                <tr>
-                  <th className="text-left px-4 py-2.5">Run ID</th>
-                  <th className="text-left px-4 py-2.5">Status</th>
-                  <th className="text-right px-4 py-2.5">In tokens</th>
-                  <th className="text-right px-4 py-2.5">Out tokens</th>
-                  <th className="text-left px-4 py-2.5">Started</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {pastRuns.map((run) => (
-                  <React.Fragment key={run.run_id}>
-                    <tr className="hover:bg-gray-50 transition-colors">
-                      <td className="px-4 py-2.5 font-mono text-xs text-gray-500 truncate max-w-[12rem]">
-                        {run.run_id}
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <StatusBadge status={run.status} />
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-gray-500 tabular-nums">
-                        {run.total_input_tokens.toLocaleString()}
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-gray-500 tabular-nums">
-                        {run.total_output_tokens.toLocaleString()}
-                      </td>
-                      <td className="px-4 py-2.5 text-gray-400 text-xs">
-                        {run.started_at ? new Date(run.started_at).toLocaleString() : '—'}
-                      </td>
-                    </tr>
-                    <tr className="bg-gray-50">
-                      <td colSpan={5} className="px-4 py-2">
-                        <PastRunViewer projectId={projectId} runId={run.run_id} />
-                      </td>
-                    </tr>
-                  </React.Fragment>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </Card>
-      )}
 
       {/* ── QA / Test Session ── */}
       <Card>
@@ -708,14 +781,6 @@ export function ProjectDetailPage() {
           </div>
         </Card>
       </div>
-
-      {/* ── Documentation ── */}
-      <Card>
-        <CardHeader title="Documentation" />
-        <div className="p-5">
-          <DocPanel projectId={projectId} />
-        </div>
-      </Card>
 
       </>}
     </div>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -522,13 +522,26 @@ function ConfigTab({ projectId }: { projectId: number }) {
   )
 }
 
+// ── Tickets tab ───────────────────────────────────────────────────────────
+
+function TicketsTab({ projectId, refreshKey }: { projectId: number; refreshKey?: number }) {
+  return (
+    <Card>
+      <CardHeader title="Bug Tickets" />
+      <div className="p-5">
+        <TicketsPanel projectId={projectId} refreshKey={refreshKey} />
+      </div>
+    </Card>
+  )
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────
 
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>()
   const projectId = Number(id)
 
-  const [activeTab, setActiveTab] = useState<'overview' | 'runs' | 'docs' | 'tests' | 'config'>('overview')
+  const [activeTab, setActiveTab] = useState<'overview' | 'tickets' | 'runs' | 'docs' | 'tests' | 'config'>('overview')
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -633,6 +646,7 @@ export function ProjectDetailPage() {
         {(
           [
             ['overview', 'Overview'],
+            ['tickets', 'Tickets'],
             ['runs', 'Runs'],
             ['docs', 'Docs'],
             ['tests', 'Tests'],
@@ -657,6 +671,7 @@ export function ProjectDetailPage() {
       {activeTab === 'tests' && <TestsTab projectId={projectId} />}
       {activeTab === 'runs' && <RunsTab projectId={projectId} pastRuns={pastRuns} />}
       {activeTab === 'docs' && <DocsTab projectId={projectId} />}
+      {activeTab === 'tickets' && <TicketsTab projectId={projectId} refreshKey={ticketsRefreshKey} />}
 
       {activeTab === 'overview' && <>
 
@@ -737,14 +752,6 @@ export function ProjectDetailPage() {
             Run a QA session to have agents automatically test, file bug tickets, and generate fixes.
           </div>
         )}
-      </Card>
-
-      {/* ── Bug Tickets ── */}
-      <Card>
-        <CardHeader title="Bug Tickets" />
-        <div className="p-5">
-          <TicketsPanel projectId={projectId} refreshKey={ticketsRefreshKey} />
-        </div>
       </Card>
 
       {/* ── Dashboards ── */}

--- a/frontend/src/test/PRActions.test.tsx
+++ b/frontend/src/test/PRActions.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { TicketsPanel } from '../components/TicketsPanel'
+
+const mockTickets = [
+  {
+    id: '2026-04-24-001',
+    title: 'GET /items returns 404',
+    content: 'Fix was applied.',
+    status: 'needs_review' as const,
+  },
+]
+
+const server = setupServer(
+  http.get('http://localhost/api/projects/1/tickets', () =>
+    HttpResponse.json(mockTickets),
+  ),
+  http.post('http://localhost/api/projects/1/pr/2026-04-24-001/accept', () =>
+    HttpResponse.json({ ticket_id: '2026-04-24-001', status: 'accepted' }),
+  ),
+  http.post('http://localhost/api/projects/1/pr/2026-04-24-001/reject', () =>
+    HttpResponse.json({ ticket_id: '2026-04-24-001', status: 'rejected' }),
+  ),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('TicketsPanel PR actions', () => {
+  it('shows needs_review ticket in the Needs Human Review column', async () => {
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() => screen.getByText('Needs Human Review'))
+    expect(screen.getByText('2026-04-24-001')).toBeInTheDocument()
+  })
+
+  it('shows Accept and Reject buttons when needs_review ticket is expanded', async () => {
+    const user = userEvent.setup()
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() => screen.getByText('2026-04-24-001'))
+    await user.click(screen.getByText('2026-04-24-001'))
+    expect(screen.getByRole('button', { name: /accept/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
+  })
+
+  it('calls accept endpoint and triggers onReviewed callback', async () => {
+    const user = userEvent.setup()
+    const onReviewed = vi.fn()
+    render(<TicketsPanel projectId={1} onReviewed={onReviewed} />)
+    await waitFor(() => screen.getByText('2026-04-24-001'))
+    await user.click(screen.getByText('2026-04-24-001'))
+    // Override GET after initial load so the refresh after accept gets closed status
+    server.use(
+      http.get('http://localhost/api/projects/1/tickets', () => {
+        return HttpResponse.json([
+          { ...mockTickets[0], status: 'closed' },
+        ])
+      }),
+    )
+    await user.click(screen.getByRole('button', { name: /accept/i }))
+    await waitFor(() => expect(onReviewed).toHaveBeenCalled())
+  })
+})

--- a/frontend/src/test/ProjectDetailPage.test.tsx
+++ b/frontend/src/test/ProjectDetailPage.test.tsx
@@ -136,19 +136,34 @@ describe('ProjectDetailPage', () => {
     await waitFor(() => expect(screen.getByTestId('qa-session-view')).toBeInTheDocument())
   })
 
-  it('renders the TicketsPanel section', async () => {
+  it('shows Tickets tab in the tab bar', async () => {
     renderPage()
+    await waitFor(() => expect(screen.getByRole('button', { name: /^tickets$/i })).toBeInTheDocument())
+  })
+
+  it('renders the TicketsPanel section', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^tickets$/i }))
+    await user.click(screen.getByRole('button', { name: /^tickets$/i }))
     await waitFor(() => expect(screen.getByTestId('tickets-panel')).toBeInTheDocument())
   })
 
   it('increments ticketsRefreshKey when QA session completes', async () => {
     const user = userEvent.setup()
     renderPage()
+    // Navigate to Tickets tab so TicketsPanel is mounted and confirm initial key=0
+    await waitFor(() => screen.getByRole('button', { name: /^tickets$/i }))
+    await user.click(screen.getByRole('button', { name: /^tickets$/i }))
+    await waitFor(() => screen.getByText(/TicketsPanel:1:0/))
+    // Go back to Overview to start QA session
+    await user.click(screen.getByRole('button', { name: /^overview$/i }))
     await waitFor(() => screen.getByRole('button', { name: /run qa session/i }))
     await user.click(screen.getByRole('button', { name: /run qa session/i }))
     await waitFor(() => screen.getByTestId('qa-session-view'))
-    expect(screen.getByText(/TicketsPanel:1:0/)).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /complete-qa/i }))
+    // Go to Tickets tab to see the updated refreshKey
+    await user.click(screen.getByRole('button', { name: /^tickets$/i }))
     await waitFor(() =>
       expect(screen.getByText(/TicketsPanel:1:1/)).toBeInTheDocument()
     )

--- a/frontend/src/test/ProjectDetailPage.test.tsx
+++ b/frontend/src/test/ProjectDetailPage.test.tsx
@@ -171,13 +171,19 @@ describe('ProjectDetailPage', () => {
         ]),
       ),
     )
+    const user = userEvent.setup()
     renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^runs$/i }))
+    await user.click(screen.getByRole('button', { name: /^runs$/i }))
     await waitFor(() => expect(screen.getByTestId('past-run-viewer')).toBeInTheDocument())
     expect(screen.getByText(/PastRunViewer:run-old-123/)).toBeInTheDocument()
   })
 
   it('renders the DocPanel section', async () => {
+    const user = userEvent.setup()
     renderPage()
+    await waitFor(() => screen.getByRole('button', { name: /^docs$/i }))
+    await user.click(screen.getByRole('button', { name: /^docs$/i }))
     await waitFor(() => expect(screen.getByTestId('doc-panel')).toBeInTheDocument())
   })
 

--- a/frontend/src/test/TicketsPanel.test.tsx
+++ b/frontend/src/test/TicketsPanel.test.tsx
@@ -10,11 +10,13 @@ const mockTickets = [
     id: '2026-04-24-001',
     title: 'GET /items returns 404',
     content: '# GET /items returns 404\nThe endpoint is missing from the router.',
+    status: 'pending_confirmation',
   },
   {
     id: '2026-04-24-002',
     title: 'POST /items ignores body',
     content: '# POST /items ignores body\nInput data is discarded.',
+    status: 'closed',
   },
 ]
 
@@ -62,12 +64,25 @@ describe('TicketsPanel', () => {
     server.use(
       http.get('http://localhost/api/projects/1/tickets', () =>
         HttpResponse.json([
-          { id: '2026-04-24-003', title: 'New ticket', content: '# New ticket\nNew content.' },
+          {
+            id: '2026-04-24-003',
+            title: 'New ticket',
+            content: '# New ticket\nNew content.',
+            status: 'pending_confirmation',
+          },
         ]),
       ),
     )
 
     rerender(<TicketsPanel projectId={1} refreshKey={1} />)
     await waitFor(() => expect(screen.getByText('2026-04-24-003')).toBeInTheDocument())
+  })
+
+  it('renders tickets in correct kanban columns', async () => {
+    render(<TicketsPanel projectId={1} />)
+    await waitFor(() => screen.getByText('Pending Confirmation'))
+    expect(screen.getByText('Closed')).toBeInTheDocument()
+    expect(screen.getByText('2026-04-24-001')).toBeInTheDocument()  // pending col
+    expect(screen.getByText('2026-04-24-002')).toBeInTheDocument()  // closed col
   })
 })


### PR DESCRIPTION
## Summary

Final submission polish bringing SMRT Agent to Definition of Done per PRODUCTION.md §15.

### M7 — Submission Polish
- README rewritten with ≤3-minute evaluator demo path
- `docs/` folder: architecture, agent-design, hitl-contract, evaluation-rubric-mapping
- Config tab: model selection, max fix attempts, scheduler cadence, thought-process toggle
- Tests tab: test-status.yaml history with filter buttons and run-history dots
- Secret guard hook: gitignore-aware file access deny for all agent tools
- `eval-fixtures/wild/README.md` soak-test guide; `bin/setup-vault.py` Obsidian vault initializer

### M8 — UI + PR surface
- **Runs tab** and **Docs tab** extracted from Overview into dedicated tabs
- **Tickets tab** with 4-column kanban: Pending Confirmation / In Progress / Needs Human Review / Closed
- **PR surface**: after coder fix + successful recheck, ticket enters `needs_review`; Accept/Reject buttons in kanban
  - Accept → `bugs-resolved.md` + Project.md Lessons + `wiki/log.md`
  - Reject → Project.md Lessons + `rejections.jsonl`
- **Blackbox self-test** (`test_blackbox_invariant.py`): 6 sync tests proving Coder cannot read/write `tests/` or `.smrt/`

### Test counts
- Frontend: 78 tests, 13 files, all passing
- Backend sync tests: 138 passing (async tests require Docker)

## Test plan
- [ ] `docker-compose up` — both containers start, `/health` returns 200
- [ ] Register `eval-fixtures/todo-api` via Projects page
- [ ] Run Init Audit → tool calls stream in Overview tab
- [ ] Run QA Session → Approve → coder fixes → Accept PR → confirm Project.md Lessons updated
- [ ] Tickets kanban shows ticket in correct column after each state transition
- [ ] Dashboards (Cost, Heatmap, DocScore) render after a completed run
- [ ] Config tab saves model selection and takes effect on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce dedicated Runs, Docs, Config, Tests, and Tickets tabs in the project detail UI and wire Tickets into a PR review surface that tracks ticket status from QA through human review and acceptance/rejection.

New Features:
- Add a Runs tab showing detailed run history with embedded past-run viewer.
- Add a Docs tab for documentation viewing and regeneration controls.
- Add a Tickets tab with a kanban-style board grouped by ticket status and PR review actions.
- Expose a backend PR surface API to list pending PRs and accept or reject fixes, updating project knowledge artifacts accordingly.
- Enforce a blackbox invariant preventing the coder agent from reading or writing tests/ and .smrt/ directories.

Enhancements:
- Persist and surface ticket status based on bugs-resolved and pending PR logs so tickets transition through pending, needs review, and closed states.
- Update Project.md lessons, wiki logs, and rejection logs when PR decisions are recorded.
- Refine frontend navigation tests to cover new tabs and ticket refresh behavior.

Tests:
- Add backend tests for ticket status computation, PR API behavior, Project.md lessons updates, and blackbox invariants around tests/ and .smrt/ access.
- Extend frontend tests to cover new tabs, kanban ticket layout, and Accept/Reject PR actions in the Tickets panel.